### PR TITLE
[BUG] Fixed if-case in rescaling func where patch value was not returned

### DIFF
--- a/AxonDeepSeg/data_management/data_augmentation.py
+++ b/AxonDeepSeg/data_management/data_augmentation.py
@@ -72,7 +72,7 @@ def rescaling(patch, factor_max=1.2, verbose=0):
 
     # If the resampling factor is too close to 1 we do not resample.
     if (new_patch_size <= patch_size+5) and (new_patch_size >= patch_size-5): # To avoid having q_h = 0
-        rescaled_patch = patch
+        return patch
     else :
         image_rescale = rescale(patch[0], scale, preserve_range= True)
         mask_rescale = rescale(patch[1], scale, preserve_range= True)


### PR DESCRIPTION
Encountered while writing tests for #76 and issue #112.

Really minor, the patch was just forgotten to be returned for the case of a rescaling factor too small (returned patch = input patch).