### PR TITLE
[SENTRY] Display full path to config file in Sentry opt-out message

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -43,10 +43,10 @@ def _main_thread_terminated(self):
                 print("Press Ctrl-C to quit")
 
             # -- Function override statement --#
-            configPath = get_config_path()
+            config_path = get_config_path()
             print ("Note: you can opt out of Sentry reporting by changing the "
                    "value of bugTracking to 0 in the "
-                   "file {}".format(configPath))
+                   "file {}".format(config_path))
             # -- EO Function override statement --#
 
             self._timed_queue_join(timeout - initial_timeout)
@@ -62,7 +62,7 @@ raven.transport.threaded.AsyncWorker.main_thread_terminated = _main_thread_termi
 
 def config_setup():
 
-    configPath = get_config_path()
+    config_path = get_config_path()
     
     if 'pytest' in sys.modules:
         bugTracking = bool(0)
@@ -78,13 +78,13 @@ def config_setup():
     if bugTracking:
         print ("Note: you can opt out of Sentry reporting by changing the "
                "value of bugTracking from 1 to 0 in the "
-               "file {}".format(configPath))
+               "file {}".format(config_path))
 
     config = ConfigParser.ConfigParser()
     config.add_section('Global')
     config.set('Global', 'bugTracking', bugTracking)
 
-    with open(configPath, 'w') as configFile:
+    with open(config_path, 'w') as configFile:
         config.write(configFile)
 
     print("Configuration saved successfully !")
@@ -102,13 +102,13 @@ def read_config():
     """Read the system configuration file.
     :return: a dict with the configuration parameters.
     """
-    configPath = get_config_path()
+    config_path = get_config_path()
 
-    if not os.path.exists(configPath):
+    if not os.path.exists(config_path):
         raise IOError("Could not find configuration file.")
 
     config = ConfigParser.ConfigParser()
-    config.read(configPath)
+    config.read(config_path)
     return config
 
 
@@ -117,9 +117,9 @@ def init_ads():
     :return:
     """
 
-    configPath = get_config_path()
+    config_path = get_config_path()
 
-    if not os.path.isfile(configPath):
+    if not os.path.isfile(config_path):
         config_setup()
     else:
         pass

--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -43,7 +43,7 @@ def _main_thread_terminated(self):
                 print("Press Ctrl-C to quit")
 
             # -- Function override statement --#
-            configPath = getConfigPath()
+            configPath = get_config_path()
             print ("Note: you can opt out of Sentry reporting by changing the "
                    "value of bugTracking to 0 in the "
                    "file {}".format(configPath))
@@ -62,7 +62,7 @@ raven.transport.threaded.AsyncWorker.main_thread_terminated = _main_thread_termi
 
 def config_setup():
 
-    configPath = getConfigPath()
+    configPath = get_config_path()
     
     if 'pytest' in sys.modules:
         bugTracking = bool(0)
@@ -89,7 +89,7 @@ def config_setup():
 
     print("Configuration saved successfully !")
 
-def getConfigPath():
+def get_config_path():
     """Get the full path of the AxonDeepSeg configuration file.
     :return: String with the full path to the ADS config file.
     """
@@ -102,7 +102,7 @@ def read_config():
     """Read the system configuration file.
     :return: a dict with the configuration parameters.
     """
-    configPath = getConfigPath()
+    configPath = get_config_path()
 
     if not os.path.exists(configPath):
         raise IOError("Could not find configuration file.")
@@ -117,7 +117,7 @@ def init_ads():
     :return:
     """
 
-    configPath = getConfigPath()
+    configPath = get_config_path()
 
     if not os.path.isfile(configPath):
         config_setup()

--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -4,7 +4,7 @@ import ConfigParser
 from distutils.util import strtobool
 import raven
 
-DEFAULT_CONFIGFILE = ".adsconfig"
+DEFAULT_CONFIGFILE = "axondeepseg.cfg"
 
 # raven function override - do not modify unless needed if raven version is
 # changed to a version other than 6.8.0.
@@ -43,10 +43,7 @@ def _main_thread_terminated(self):
                 print("Press Ctrl-C to quit")
 
             # -- Function override statement --#
-            configPath = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                DEFAULT_CONFIGFILE
-                )
+            configPath = getConfigPath()
             print ("Note: you can opt out of Sentry reporting by changing the "
                    "value of bugTracking to 0 in the "
                    "file {}".format(configPath))
@@ -65,10 +62,7 @@ raven.transport.threaded.AsyncWorker.main_thread_terminated = _main_thread_termi
 
 def config_setup():
 
-    configPath = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        DEFAULT_CONFIGFILE
-        )
+    configPath = getConfigPath()
     
     if 'pytest' in sys.modules:
         bugTracking = bool(0)
@@ -95,15 +89,20 @@ def config_setup():
 
     print("Configuration saved successfully !")
 
+def getConfigPath():
+    """Get the full path of the AxonDeepSeg configuration file.
+    :return: String with the full path to the ADS config file.
+    """
+    return os.path.join(
+                    os.path.expanduser("~"),
+                    DEFAULT_CONFIGFILE
+                    )
 
 def read_config():
     """Read the system configuration file.
     :return: a dict with the configuration parameters.
     """
-    configPath = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        DEFAULT_CONFIGFILE
-        )
+    configPath = getConfigPath()
 
     if not os.path.exists(configPath):
         raise IOError("Could not find configuration file.")
@@ -118,10 +117,7 @@ def init_ads():
     :return:
     """
 
-    configPath = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        DEFAULT_CONFIGFILE
-        )
+    configPath = getConfigPath()
 
     if not os.path.isfile(configPath):
         config_setup()

--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -43,9 +43,14 @@ def _main_thread_terminated(self):
                 print("Press Ctrl-C to quit")
 
             # -- Function override statement --#
+            configPath = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                DEFAULT_CONFIGFILE
+                )
             print ("Note: you can opt out of Sentry reporting by changing the "
                    "value of bugTracking to 0 in the "
-                   "file AxonDeepSeg/.adsconfig")
+                   "file {}".format(configPath))
+            # -- EO Function override statement --#
 
             self._timed_queue_join(timeout - initial_timeout)
 
@@ -79,7 +84,7 @@ def config_setup():
     if bugTracking:
         print ("Note: you can opt out of Sentry reporting by changing the "
                "value of bugTracking from 1 to 0 in the "
-               "file AxonDeepSeg/.adsconfig")
+               "file {}".format(configPath))
 
     config = ConfigParser.ConfigParser()
     config.add_section('Global')


### PR DESCRIPTION
Updated the Sentry opt-out message from:

`Note: you can opt out of Sentry reporting by changing the value of bugTracking to 0 in the file AxonDeepSeg/.adsconfig`

to display the full path of the location of the file to change to opt-out, e.g.:

`Note: you can opt out of Sentry reporting by changing the value of bugTracking to 0 in the file /Users/mathieuboudreau/neuropoly/github/axondeepseg/AxonDeepSeg/.adsconfig`

since for people who install via `pip`, the folder "AxonDeepSeg" created in their virtalenv folder may be difficult to find.