### PR TITLE
[REF] Resolve rescale mode warnings

### DIFF
--- a/AxonDeepSeg/__init__.py
+++ b/AxonDeepSeg/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0"
+__version__ = "2.1dev"

--- a/AxonDeepSeg/data_management/data_augmentation.py
+++ b/AxonDeepSeg/data_management/data_augmentation.py
@@ -75,10 +75,10 @@ def rescaling(patch, factor_max=1.2, verbose=0):
     if (new_patch_size <= patch_size+5) and (new_patch_size >= patch_size-5): # To avoid having q_h = 0
         return patch
     else :
-        image_rescale = rescale(patch[0], scale, preserve_range= True)
-        mask_rescale = rescale(patch[1], scale, preserve_range= True)
+        image_rescale = rescale(patch[0], scale, preserve_range= True, mode='constant')
+        mask_rescale = rescale(patch[1], scale, preserve_range= True, mode='constant')
         if len(patch) == 3:
-            weights_rescale = rescale(patch[2], scale, preserve_range=True)
+            weights_rescale = rescale(patch[2], scale, preserve_range=True, mode='constant')
 
         s_r = mask_rescale.shape[0]
         q_h, r_h = divmod(patch_size-s_r,2)

--- a/AxonDeepSeg/data_management/dataset_building.py
+++ b/AxonDeepSeg/data_management/dataset_building.py
@@ -41,11 +41,11 @@ def raw_img_to_patches(path_raw_data, path_patched_data, thresh_indices = [0, 0.
             for data in os.listdir(path_img_folder):
                 if 'image' in data: # If it's the raw image.
                     img = imread(os.path.join(path_img_folder, data), flatten=False, mode='L')
-                    img = rescale(img, resample_coeff, preserve_range=True).astype(int)
+                    img = rescale(img, resample_coeff, preserve_range=True, mode='constant').astype(int)
                   
                 elif 'mask.png' in data:
                     mask_init = imread(os.path.join(path_img_folder, data), flatten=False, mode='L')
-                    mask = rescale(mask_init, resample_coeff, preserve_range=True)
+                    mask = rescale(mask_init, resample_coeff, preserve_range=True, mode='constant')
 
                     # Set the mask values to the classes' values
                     mask = labellize_mask_2d(mask, thresh_indices)  # shape (size, size), values float 0.0-1.0


### PR DESCRIPTION
When running tests and/or calling certain functions, the following warnings appeared:

*/Users/mathieuboudreau/anaconda3/envs/ads36_venv/lib/python3.6/site-packages/skimage/transform/_warps.py:84: UserWarning: The default mode, 'constant', will be changed to 'reflect' in skimage 0.15.*

This happens in two locations, in our rescaling data augmentation tools, and in `raw_img_to_patches` function.

I resolved in this branch this by explicitly setting the mode value to `constant` in the function calls.

**However,**

by looking at the documentation, it appears to me that setting it to `reflect` might be the behaviour that we actually want? @perone what do you think?

...

mode : {‘constant’, ‘edge’, ‘symmetric’, ‘reflect’, ‘wrap’}, optional
Points outside the boundaries of the input are filled according to the given mode. Modes match the behaviour of numpy.pad.

...


**Notes**

**Modes ‘reflect’ and ‘symmetric’ are similar, but differ in whether the edge pixels are duplicated during the reflection. As an example, if an array has values [0, 1, 2] and was padded to the right by four values using symmetric, the result would be [0, 1, 2, 2, 1, 0, 0], while for reflect it would be [0, 1, 2, 1, 0, 1, 2].**

Edit: `mode='constant'` is used explicitly in numerous other locations, so let's keep it constant here until we test otherwise. e.g. https://github.com/neuropoly/axondeepseg/blob/03e2a2c3ecd464a0a1c86710121e429489e0eaa4/AxonDeepSeg/data_management/data_augmentation.py#L174-L175