### PR TITLE
[REF] Revert tensorflow req to 1.3.0 and remove tifffile requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scikit-image==0.13.1
 tabulate==0.8.2
 pandas==0.23.3
 matplotlib==2.2.2
-tensorflow==1.9.0
+tensorflow==1.3.0
 mpld3==0.3
 tqdm==4.24.0
 pillow==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ pytest==3.5.0
 pytest-cov==2.5.1
 prettytable==0.7.2
 raven==6.8.0
-tifffile==0.14.0


### PR DESCRIPTION
As pointed out by @perone, tensorflow might behave differently for newer versions, so we might as well stick with 1.3.0 as originally intended (although before, we had a req of >= 1.3.0, so whatever was installed at any given time was the most up to date version). I had fixed it to 1.9.0 as it was the most up-to-date version at the time (thus, the one being installed anyways). Also, the CUDA libraries installed on Rosenberg at the moment (or at least, for me as a user) aren't compatible with tensorflow versions >= 1.5.0.

Also removing the tifffile requirement. That one was added recently because imageio shouts warnings for tiffiles that it's not optimized for speed without tifffile installed (see: https://github.com/imageio/imageio/issues/350). This worked fine for me on my local (MacOSX), and on Travis tests (Linux), however when I tried installing the pip requirement on Rosenberg, C-librarie errors were thrown:

<details>

```

Building wheels for collected packages: tifffile
  Running setup.py bdist_wheel for tifffile ... error
  Complete output from command /home/mabou_local/venv_ads2/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-_bumnz1q/tifffile/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-b2cvauy8 --python-tag cp36:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/tifffile
  copying tifffile/__init__.py -> build/lib.linux-x86_64-3.6/tifffile
  copying tifffile/tifffile.py -> build/lib.linux-x86_64-3.6/tifffile
  running egg_info
  writing tifffile.egg-info/PKG-INFO
  writing dependency_links to tifffile.egg-info/dependency_links.txt
  writing requirements to tifffile.egg-info/requires.txt
  writing top-level names to tifffile.egg-info/top_level.txt
  reading manifest file 'tifffile.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no previously-included files matching '__pycache__' found under directory '*'
  warning: no previously-included files matching '*.py[co]' found under directory '*'
  writing manifest file 'tifffile.egg-info/SOURCES.txt'
  copying tifffile/_tifffile.c -> build/lib.linux-x86_64-3.6/tifffile
  running build_ext
  building 'tifffile._tifffile' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/tifffile
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/home/mabou_local/venv_ads2/lib/python3.6/site-packages/numpy/core/include -I/usr/include/python3.6m -c tifffile/_tifffile.c -o build/temp.linux-x86_64-3.6/tifffile/_tifffile.o
  tifffile/_tifffile.c:73:20: erreur fatale: Python.h : Aucun fichier ou dossier de ce type
   #include "Python.h"
                      ^
  compilation terminée.
  error: command 'gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for tifffile
  Running setup.py clean for tifffile
Failed to build tifffile
Installing collected packages: tensorflow, tifffile, AxonDeepSeg
  Found existing installation: tifffile 2018.10.18
    Uninstalling tifffile-2018.10.18:
      Successfully uninstalled tifffile-2018.10.18
  Running setup.py install for tifffile ... error
    Complete output from command /home/mabou_local/venv_ads2/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-_bumnz1q/tifffile/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-kh13odk8/install-record.txt --single-version-externally-managed --compile --install-headers /home/mabou_local/venv_ads2/include/site/python3.6/tifffile:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.6
    creating build/lib.linux-x86_64-3.6/tifffile
    copying tifffile/__init__.py -> build/lib.linux-x86_64-3.6/tifffile
    copying tifffile/tifffile.py -> build/lib.linux-x86_64-3.6/tifffile
    running egg_info
    writing tifffile.egg-info/PKG-INFO
    writing dependency_links to tifffile.egg-info/dependency_links.txt
    writing requirements to tifffile.egg-info/requires.txt
    writing top-level names to tifffile.egg-info/top_level.txt
    reading manifest file 'tifffile.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no previously-included files matching '__pycache__' found under directory '*'
    warning: no previously-included files matching '*.py[co]' found under directory '*'
    writing manifest file 'tifffile.egg-info/SOURCES.txt'
    copying tifffile/_tifffile.c -> build/lib.linux-x86_64-3.6/tifffile
    running build_ext
    building 'tifffile._tifffile' extension
    creating build/temp.linux-x86_64-3.6
    creating build/temp.linux-x86_64-3.6/tifffile
    gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/home/mabou_local/venv_ads2/lib/python3.6/site-packages/numpy/core/include -I/usr/include/python3.6m -c tifffile/_tifffile.c -o build/temp.linux-x86_64-3.6/tifffile/_tifffile.o
    tifffile/_tifffile.c:73:20: erreur fatale: Python.h : Aucun fichier ou dossier de ce type
     #include "Python.h"
                        ^
    compilation terminée.
    error: command 'gcc' failed with exit status 1
    
    ----------------------------------------
  Rolling back uninstall of tifffile
Command "/home/mabou_local/venv_ads2/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-_bumnz1q/tifffile/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-kh13odk8/install-record.txt --single-version-externally-managed --compile --install-headers /home/mabou_local/venv_ads2/include/site/python3.6/tifffile" failed with error code 1 in /tmp/pip-install-_bumnz1q/tifffile/


```

</details></p>

We'll just have to bear with the warnings until imageio gets updated and this issue is resolved. Warnings are only shown to users for tiff files, ans since most of our files are png, this isn't too much of a nuissance (I hope).