### PR TITLE
DOC: Fixed print syntax with Py3k

### DIFF
--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -418,8 +418,8 @@
     "dice_axon = pw_dice(pred_axon, gt_axon)\n",
     "dice_myelin = pw_dice(pred_myelin, gt_myelin)\n",
     "\n",
-    "print 'Dice for Axon : ' + str(dice_axon)\n",
-    "print 'Dice for myelin : ' + str(dice_myelin)"
+    "print('Dice for Axon : ' + str(dice_axon))\n",
+    "print('Dice for myelin : ' + str(dice_myelin))"
    ]
   },
   {

--- a/notebooks/morphometrics_extraction.ipynb
+++ b/notebooks/morphometrics_extraction.ipynb
@@ -255,7 +255,7 @@
    "source": [
     "# Compute aggregate metrics\n",
     "aggregate_metrics = get_aggregate_morphometrics(pred_axon,pred_myelin,path_folder)\n",
-    "print aggregate_metrics"
+    "print(aggregate_metrics)"
    ]
   },
   {
@@ -296,7 +296,7 @@
    ],
    "source": [
     "# Show metrics available for axons\n",
-    "print stats_array[0].keys()"
+    "print(stats_array[0].keys())"
    ]
   },
   {
@@ -314,7 +314,7 @@
    ],
    "source": [
     "# Get axon diameter value of axon object 0\n",
-    "print stats_array[0]['axon_diam']"
+    "print(stats_array[0]['axon_diam'])"
    ]
   },
   {
@@ -332,7 +332,7 @@
    ],
    "source": [
     "# Get solidity value of axon object 50\n",
-    "print stats_array[49]['solidity']"
+    "print(stats_array[49]['solidity'])"
    ]
   },
   {
@@ -350,7 +350,7 @@
    ],
    "source": [
     "# Display all stats for axon object 10\n",
-    "print stats_array[9]"
+    "print(stats_array[9])"
    ]
   },
   {
@@ -378,7 +378,7 @@
    ],
    "source": [
     "# Get number of axons in sample\n",
-    "print np.size(axon_diam_list)"
+    "print(np.size(axon_diam_list))"
    ]
   },
   {
@@ -397,7 +397,7 @@
    "source": [
     "# Get mean diameter\n",
     "mean_diam = np.mean(axon_diam_list)\n",
-    "print mean_diam"
+    "print(mean_diam)"
    ]
   },
   {
@@ -416,7 +416,7 @@
    "source": [
     "# Get max diameter\n",
     "max_diam = np.max(axon_diam_list)\n",
-    "print max_diam"
+    "print(max_diam)"
    ]
   },
   {

--- a/notebooks/segmentation_image.ipynb
+++ b/notebooks/segmentation_image.ipynb
@@ -449,8 +449,8 @@
     "dice_axon = pw_dice(pred_axon, gt_axon)\n",
     "dice_myelin = pw_dice(pred_myelin, gt_myelin)\n",
     "\n",
-    "print 'Dice for Axon : ' + str(dice_axon)\n",
-    "print 'Dice for myelin : ' + str(dice_myelin)"
+    "print('Dice for Axon : ' + str(dice_axon))",
+    "print('Dice for myelin : ' + str(dice_myelin))"
    ]
   },
   {


### PR DESCRIPTION
Replaced print " " with print("") on a few Jupyter notebooks (which crashed with Py3K).