### PR TITLE
Change Evaluation Of Myelin Thickness And Area

### DIFF
--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -197,6 +197,7 @@ def warn_if_measures_are_unexpected(axon_object, axonmyelin_object, attribute):
         x_a, y_a = axon_object.centroid
         x_am, y_am = axonmyelin_object.centroid
         data = {
+            "attribute": attribute,
             "axon_label": axon_object.label,
             "x_a": x_a,
             "y_a": y_a,
@@ -204,9 +205,9 @@ def warn_if_measures_are_unexpected(axon_object, axonmyelin_object, attribute):
             "x_am": x_am,
             "y_am": y_am
         }
-        warning = Template("Warning, axon #$axon_label at ($x_a, $y_a) and" +
-            "corresponding myelinated axon #$axonmyelin_label$ at ($x_am, $y_am)" +
-            "have unexpected measure values." 
+        warning = Template("Warning, axon #$axon_label at ($x_a, $y_a) and " +
+            "corresponding myelinated axon #$axonmyelin_label at ($x_am, $y_am) " +
+            "have unexpected measure values for $attribute attributest."
             )
         print(warning.safe_substitute(data))
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -150,8 +150,8 @@ def get_axon_morphometrics(im_axon, path_folder, im_myelin=None):
 
 def evaluate_myelin_thickness_in_px(axon_object, axonmyelin_object):
     """
-    Returns the outer equivalent diameter for the myelinated axon minus the
-    axon equivalent diameter (see note [1] below). The result is in pixels.
+    Returns the equivavent thickness of a myelin ring around an axon of a
+    given equivalent diameter (see note [1] below). The result is in pixels.
     :param axon_object (skimage.measure._regionprops): object returned after
         measuring a axon labeled region
     :param axonmyelin_object (skimage.measure._regionprops): object returned after
@@ -169,7 +169,7 @@ def evaluate_myelin_thickness_in_px(axon_object, axonmyelin_object):
 
     axon_diam = axon_object.equivalent_diameter
     axonmyelin_diam = axonmyelin_object.equivalent_diameter
-    return axonmyelin_diam - axon_diam
+    return (axonmyelin_diam - axon_diam)/2
 
 def evaluate_myelin_area_in_px(axon_object, axonmyelin_object):
     """

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -105,7 +105,7 @@ class TestCore(object):
             flatten=True)
 
         stats_array = get_axon_morphometrics(pred_axon, path_folder, im_myelin=pred_myelin)
-        
+
         assert stats_array[1]['gratio'] == pytest.approx(0.74, rel=0.01)
 
     @pytest.mark.unit
@@ -115,7 +115,7 @@ class TestCore(object):
             '__test_files__',
             '__test_simulated_axons__',
             'SimulatedAxons.png')
-        
+
         gratio_sim = [
                       0.9,
                       0.8,
@@ -153,6 +153,26 @@ class TestCore(object):
             assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
             assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
 
+    @pytest.mark.unit
+    def test_get_axon_morphometrics_with_wrong_myelin_mask_simulated_axons(self):
+        path_pred = os.path.join(
+            self.testPath,
+            '__test_files__',
+            '__test_simulated_axons__',
+            'SimulatedAxons.png')
+
+        # Read paths and compute axon/myelin masks
+        pred = scipy_imread(path_pred, flatten=True)
+        pred_axon = pred > 200
+        wrong_pred_myelin = np.zeros(pred.shape)
+        path_folder, file_name = os.path.split(path_pred)
+
+        # Compute axon morphometrics
+        stats_array = get_axon_morphometrics(pred_axon,path_folder,im_myelin=wrong_pred_myelin)
+        for axon_prop in stats_array:
+            assert axon_prop['myelin_thickness'] == pytest.approx(0.0, rel=0.01)
+            assert axon_prop['myelin_area'] == pytest.approx(0.0, rel=0.01)
+            assert axon_prop['gratio'] == pytest.approx(1.0, rel=0.01)
 
     # --------------save and load _axon_morphometrics tests-------------- #
     @pytest.mark.unit

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -108,7 +108,7 @@ class TestCore(object):
 
         assert stats_array[1]['gratio'] == pytest.approx(0.74, rel=0.01)
 
-    @pytest.mark.single
+    @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons(self):
         path_pred = os.path.join(
             self.testPath,

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -154,7 +154,7 @@ class TestCore(object):
             assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
 
     @pytest.mark.unit
-    def test_get_axon_morphometrics_with_wrong_myelin_mask_simulated_axons(self):
+    def test_get_axon_morphometrics_with_unexpected_myelin_mask_simulated_axons(self):
         path_pred = os.path.join(
             self.testPath,
             '__test_files__',
@@ -164,11 +164,11 @@ class TestCore(object):
         # Read paths and compute axon/myelin masks
         pred = scipy_imread(path_pred, flatten=True)
         pred_axon = pred > 200
-        wrong_pred_myelin = np.zeros(pred.shape)
+        unexpected_pred_myelin = np.zeros(pred.shape)
         path_folder, file_name = os.path.split(path_pred)
 
         # Compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon,path_folder,im_myelin=wrong_pred_myelin)
+        stats_array = get_axon_morphometrics(pred_axon,path_folder,im_myelin=unexpected_pred_myelin)
         for axon_prop in stats_array:
             assert axon_prop['myelin_thickness'] == pytest.approx(0.0, rel=0.01)
             assert axon_prop['myelin_area'] == pytest.approx(0.0, rel=0.01)

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -108,7 +108,7 @@ class TestCore(object):
 
         assert stats_array[1]['gratio'] == pytest.approx(0.74, rel=0.01)
 
-    @pytest.mark.unit
+    @pytest.mark.single
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons(self):
         path_pred = os.path.join(
             self.testPath,
@@ -116,29 +116,31 @@ class TestCore(object):
             '__test_simulated_axons__',
             'SimulatedAxons.png')
 
-        gratio_sim = [
-                      0.9,
-                      0.8,
-                      0.7,
-                      0.6,
-                      0.5,
-                      0.4,
-                      0.3,
-                      0.2,
-                      0.1
-                     ]
+        gratio_sim = np.array([
+                                0.9,
+                                0.8,
+                                0.7,
+                                0.6,
+                                0.5,
+                                0.4,
+                                0.3,
+                                0.2,
+                                0.1
+                                ])
 
-        axon_diam_sim = [
-                         100,
-                         90,
-                         80,
-                         70,
-                         60,
-                         46,
-                         36,
-                         24,
-                         12
-                        ]
+        axon_diam_sim = np.array([
+                                100,
+                                90,
+                                80,
+                                70,
+                                60,
+                                46,
+                                36,
+                                24,
+                                12
+                                ])
+
+        myelin_thickness_sim = (axon_diam_sim/2)*(1/gratio_sim-1)
 
         # Read paths and compute axon/myelin masks
         pred = scipy_imread(path_pred)
@@ -152,6 +154,7 @@ class TestCore(object):
         for ii in range(0,9):
             assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
             assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_unexpected_myelin_mask_simulated_axons(self):


### PR DESCRIPTION
Will fix #190. 
Now, the thickness and area of the myelin is relative to its corresponding axon.
Error handling for equivalent diameter and area values has been added with the `_check_measures_are_relatively_valid` method.

`test_compute_morphometrics.py`: Add a unit test  for cases where no myelin was detected.
