### PR TITLE
Update installation doc + fix RTD bug

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,11 +14,11 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use Path().resolve() to make it absolute, like shown here.
+# documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-from pathlib import Path
+import os
 import sys
-sys.path.insert(0, Path('../..').resolve())
+sys.path.insert(0, os.path.abspath('../..'))
 
 import AxonDeepSeg
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -126,8 +126,11 @@ To install Miniconda, run the following commands in your terminal:::
     cd ~
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda
-    echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
-    source ~/.bashrc
+    echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bash_profile
+    source ~/.bash_profile
+
+.. NOTE ::
+   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try substituting ``~/.bash_profile`` with ``~/.bashrc``, or ask your sysadmin which startup script you are using.
 
 macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -139,6 +142,9 @@ To install Miniconda, run the following commands in your terminal:::
     bash ~/miniconda.sh -b -p $HOME/miniconda
     echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bash_profile
     source ~/.bash_profile
+
+.. NOTE ::
+   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try substituting ``~/.bash_profile`` with ``~/.bashrc``, or ask your sysadmin which startup script you are using.
 
 Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -130,7 +130,7 @@ To install Miniconda, run the following commands in your terminal:::
     source ~/.bashrc
 
 .. NOTE ::
-   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try adding the line `source ~/.bashrc` to your ``~/.bash_profile`` file. `See here <http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html>`_ for more details.
+   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try adding the line ``source ~/.bashrc`` to your ``~/.bash_profile`` file. `See here <http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html>`_ for more details.
 
 macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -130,7 +130,7 @@ To install Miniconda, run the following commands in your terminal:::
     source ~/.bashrc
 
 .. NOTE ::
-   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try adding the line `source ~/.bashrc` to your ``~/.bash_profile`` file. `See here<http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html>`_ for more details.
+   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try adding the line `source ~/.bashrc` to your ``~/.bash_profile`` file. `See here <http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html>`_ for more details.
 
 macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -126,11 +126,11 @@ To install Miniconda, run the following commands in your terminal:::
     cd ~
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda
-    echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bash_profile
-    source ~/.bash_profile
+    echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
+    source ~/.bashrc
 
 .. NOTE ::
-   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try substituting ``~/.bash_profile`` with ``~/.bashrc``, or ask your sysadmin which startup script you are using.
+   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try adding the line `source ~/.bashrc` to your ``~/.bash_profile`` file. `See here<http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html>`_ for more details.
 
 macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,9 +142,6 @@ To install Miniconda, run the following commands in your terminal:::
     bash ~/miniconda.sh -b -p $HOME/miniconda
     echo ". ~/miniconda/etc/profile.d/conda.sh" >> ~/.bash_profile
     source ~/.bash_profile
-
-.. NOTE ::
-   If ``conda`` isn't available on new terminal sessions after running these steps, it's possible that your system is configured to use a different startup script. Try substituting ``~/.bash_profile`` with ``~/.bashrc``, or ask your sysadmin which startup script you are using.
 
 Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* Adds some additional instructions in case `conda` is not available in new sessions after installation
* Fixes a bug that cause ReadTheDocs to fail (cannot use `pathlib`/`Path`calls to the RTD config file, as it's not compiled using our environment)