### PR TITLE
Fix relative imports

### DIFF
--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -10,9 +10,9 @@ from AxonDeepSeg.network_construction import *
 import AxonDeepSeg.ads_utils
 from AxonDeepSeg.ads_utils import convert_path
 
-from .visualization.get_masks import get_masks
-from .patch_management_tools import im2patches_overlap, patches2im_overlap
-from .config_tools import update_config, default_configuration
+from AxonDeepSeg.visualization.get_masks import get_masks
+from AxonDeepSeg.patch_management_tools import im2patches_overlap, patches2im_overlap
+from AxonDeepSeg.config_tools import update_config, default_configuration
 
 def apply_convnet(path_acquisitions, acquisitions_resolutions, path_model_folder, config_dict, ckpt_name='model',
                   inference_batch_size=1, overlap_value=25, resampled_resolutions=[0.1],

--- a/AxonDeepSeg/data_management/data_augmentation.py
+++ b/AxonDeepSeg/data_management/data_augmentation.py
@@ -5,7 +5,7 @@ from skimage import transform
 from skimage.filters import gaussian
 import numpy as np
 import random
-from .patch_extraction import extract_patch
+from AxonDeepSeg.data_management.patch_extraction import extract_patch
 import AxonDeepSeg.ads_utils
 
 #######################################################################################################################

--- a/AxonDeepSeg/data_management/dataset_building.py
+++ b/AxonDeepSeg/data_management/dataset_building.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 import AxonDeepSeg.ads_utils
 from AxonDeepSeg.data_management.input_data import labellize_mask_2d
-from .patch_extraction import extract_patch
+from AxonDeepSeg.data_management.patch_extraction import extract_patch
 from AxonDeepSeg.ads_utils import convert_path
 
 def raw_img_to_patches(path_raw_data, path_patched_data, thresh_indices = [0, 0.2, 0.8],

--- a/AxonDeepSeg/data_management/input_data.py
+++ b/AxonDeepSeg/data_management/input_data.py
@@ -14,7 +14,7 @@ from skimage import exposure
 # AxonDeepSeg imports
 import AxonDeepSeg.ads_utils
 from AxonDeepSeg.patch_management_tools import apply_legacy_preprocess, apply_preprocess
-from .data_augmentation import *
+from AxonDeepSeg.data_management.data_augmentation import *
 
 
 def generate_list_transformations(transformations = {}, thresh_indices = [0,0.5], verbose=0):

--- a/AxonDeepSeg/network_construction.py
+++ b/AxonDeepSeg/network_construction.py
@@ -7,8 +7,8 @@ import os
 os.environ['TF_CPP_MIN_LOG_LEVEL']='2' # Get rid of Tensorflow warnings.
 import tensorflow as tf
 import pickle
-from .data_management.input_data import input_data
-from .config_tools import generate_config
+from AxonDeepSeg.data_management.input_data import input_data
+from AxonDeepSeg.config_tools import generate_config
 import AxonDeepSeg.ads_utils
 
 

--- a/AxonDeepSeg/train_network.py
+++ b/AxonDeepSeg/train_network.py
@@ -13,8 +13,8 @@ from AxonDeepSeg.train_network_tools import *
 import AxonDeepSeg.ads_utils
 from AxonDeepSeg.ads_utils import convert_path
 
-from .data_management.input_data import input_data
-from .config_tools import generate_config
+from AxonDeepSeg.data_management.input_data import input_data
+from AxonDeepSeg.config_tools import generate_config
 
 
 def train_model(path_trainingset, path_model, config, path_model_init=None,

--- a/AxonDeepSeg/visualization/visualize.py
+++ b/AxonDeepSeg/visualization/visualize.py
@@ -18,7 +18,7 @@ from matplotlib.figure import Figure
 # AxonDeepSeg imports
 import AxonDeepSeg.ads_utils
 from AxonDeepSeg.ads_utils import convert_path
-from ..testing.segmentation_scoring import score_analysis, dice
+from AxonDeepSeg.testing.segmentation_scoring import score_analysis, dice
 
 
 def visualize_training(path_model, iteration_start_for_viz=0):


### PR DESCRIPTION
This PR handles the bug import error occurred while importing ADS scripts. Errors such as 

```
Traceback (most recent call last):
 File "/Users/vasudevsharma/PycharmProjects/axondeepseg/AxonDeepSeg/apply_model.py", line 13, in <module>
   from .visualization.get_masks import get_masks
ModuleNotFoundError: No module named '__main__.visualization'; '__main__' is not a package
```
are commonly faced when working on  ADS scripts.