### PR TITLE
Enforce Python 3.6.x version during setup

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -13,13 +13,14 @@ Version [2.2dev] - XXXX-XX-XX
 
 **Changed:**
 
-- Shifted AxonDeepSeg from TensorFlow to Keras framework.
-- Upgraded CUDA to 10.0 and tensorflow to 1.13.1.
 - Resolve image rescale warnings
 - Handle exception for images smaller than minimum patch size after resizing
 - Revert tensorflow requirekment to 1.3.0 and remove tifffile requirement
 - Remove `matplotlib.pyplot` from source code and refactor to full OO plotting
 - Standardize path management to `pathlib` library
+- Shifted AxonDeepSeg from TensorFlow to Keras framework.
+- Upgraded CUDA to 10.0 and tensorflow to 1.13.1.
+- Require Python 3.6.x version at installation
 
 
 Version [2.1] - 2018-09-25
@@ -105,7 +106,7 @@ The following sections will help you install all the tools you need to run AxonD
 
 Miniconda
 -------------------------------------------------------------------------------
-Starting with versions 2.0+, AxonDeepSeg is only supported using Python 3.0. Although your system may already have
+Starting with versions 2.0+, AxonDeepSeg is only supported using Python 3.6.x. Although your system may already have
 a Python environment installed, we strongly recommend that AxonDeepSeg be used with `Miniconda <https://conda.io/docs/glossary.html#miniconda-glossary>`_, which is a lightweight version
 version of the `Anaconda distribution <https://www.anaconda.com/distribution/>`_. Miniconda is typically used to create
 virtual Python environments, which provides a separation of installation dependencies between different Python projects. Although

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,24 @@
-from pathlib import Path
 from setuptools import setup, find_packages
 from codecs import open
-#from os import path
+from os import path
 
 import AxonDeepSeg
 
 
 # Get the directory where this current file is saved
-here = Path(__file__).resolve().parent
+here = path.abspath(path.dirname(__file__))
 
-with open(here / 'README.md', encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-req_path = here / 'requirements.txt'
+req_path = path.join(here, 'requirements.txt')
 with open(req_path, "r") as f:
     install_reqs = f.read().strip()
     install_reqs = install_reqs.split("\n")
 
 setup(
     name='AxonDeepSeg',
+    python_requires='>=3.6, <3.7',
     version=AxonDeepSeg.__version__,
     description='Python tool for automatic axon and myelin segmentation',
     long_description=long_description,


### PR DESCRIPTION
Changes
* Only allow ADS installation for Python versions 3.6.x 
* Revert Path() syntax in setup.y, which errors for versions before <=3.5 without a descriptive message (related to Python version).

If someone tried to install ADS with an incompatible Python version, they will now get something like following message.

>`AxonDeepSeg requires Python '>=3.6, <3.7' but the running Python is 3.5.2`

I looked into if I could customise this message or append one, but after a lot of searching it appears it's not possible (for unsuccessful installs).
