### PR TITLE
 Remove hardcoded RTD changelog; import instead CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,82 +1,89 @@
-# Changelog
+Changelog
+===============================================================================
 
-All notable changes to the AxonDeepSeg project will be documented in this file.
+Version [2.2dev] - XXXX-XX-XX
+-------------------------------------------------------------------------------
 
-## [2.2dev] - XXXX-XX-XX
+**Changed:**
 
-### Changed
-
+- Shifted AxonDeepSeg from TensorFlow to Keras framework.
+- Upgraded CUDA to 10.0 and tensorflow to 1.13.1.
 - Resolve image rescale warnings
 - Handle exception for images smaller than minimum patch size after resizing
 - Revert tensorflow requirekment to 1.3.0 and remove tifffile requirement
-- Remove `matplotlib.pyplot` from source code and refactor it to full OO plotting
+- Remove `matplotlib.pyplot` from source code and refactor to full OO plotting
 - Standardize path management to `pathlib` library
-- Shifted AxonDeepSeg from TensorFlow to Keras framework.
-- Upgraded CUDA to 10.0 and tensorflow to 1.13.1.
 
-## [2.1] - 2018-09-25
 
-### Changed
+Version [2.1] - 2018-09-25
+-------------------------------------------------------------------------------
+
+**Changed:**
 
 - Fixed bug that would crash when user inputed consent for Sentry tracking
 
-## [2.0] - 2018-09-11
+Version [2.0] - 2018-09-11
+-------------------------------------------------------------------------------
 
-### Changed
+**Changed:**
 
 - Upgraded ADS for Python 3.6-compatibility (no longer supporting Python 2.7)
 - Minor changes to make ADS Windows-compatibile
 - Removed plot hold commands (deprecated)
 
-## [1.1] - 2018-08-02
+Version [1.1] - 2018-08-02
+-------------------------------------------------------------------------------
 
-### Changed
+**Changed:**
 
 - Minor Mac OSX-related bug fix
 - Changed installation requirements to exact release versions
 
-## [1.0] - 2018-08-02
+Version [1.0] - 2018-08-02
+-------------------------------------------------------------------------------
 
 Versions 1.x will remain Python 2.7-compatible
 
-## [0.6] - 2018-08-01
+Version [0.6] - 2018-08-01
+-------------------------------------------------------------------------------
 
 (version 0.5 was skipped due to conflicting file on PyPI)
 
-### Added
+**Added:**
 
 - Comprehensive testing suite
 - Bug tracking (Sentry)
 - Blue-red visualisation function for segmented masks
 
-### Changed
+**Changed:**
 
 - Dataset building and training notebook
 - Minor documentation improvements
 - Minor bug fixes
 
-## [0.4.1] - 2018-05-16
+Version [0.4.1] - 2018-05-16
+-------------------------------------------------------------------------------
 
-### Added
+**Added:**
 
 - GIMP procedure for ground truth labelling or segmentation correction added in the documentation.
 - Compatibility with tiff images.
 - Continuous integration with Travis is now supported.
 
-### Changed
+**Changed:**
 
 - The documentation website is now hosted on ReadTheDocs.
 - Updated documentation on the usage of AxonDeepSeg.
 - Change of axon and myelin masks filenames for better clarity.
 
-## [0.3] - 2018-02-22
+Version [0.3] - 2018-02-22
+-------------------------------------------------------------------------------
 
-### Added
+**Added:**
 
 - Compatibility for image inputs other than png
 - Pre-processing of input images is now done inside AxonDeepSeg
 
-### Changed
+**Changed:**
 
 - Help display when running AxonDeepSeg from terminal
-

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -5,96 +5,6 @@ sheaths from microscopy images. It performs 3-class semantic segmentation using 
 
 AxonDeepSeg was developed by NeuroPoly, the neuroimagery laboratory of Polytechnique Montréal.
 
-Changelog
-===============================================================================
-
-Version [2.2dev] - XXXX-XX-XX
--------------------------------------------------------------------------------
-
-**Changed:**
-
-- Shifted AxonDeepSeg from TensorFlow to Keras framework.
-- Upgraded CUDA to 10.0 and tensorflow to 1.13.1.
-- Resolve image rescale warnings
-- Handle exception for images smaller than minimum patch size after resizing
-- Revert tensorflow requirekment to 1.3.0 and remove tifffile requirement
-- Remove `matplotlib.pyplot` from source code and refactor to full OO plotting
-- Standardize path management to `pathlib` library
-
-
-Version [2.1] - 2018-09-25
--------------------------------------------------------------------------------
-
-**Changed:**
-
-- Fixed bug that would crash when user inputed consent for Sentry tracking
-
-Version [2.0] - 2018-09-11
--------------------------------------------------------------------------------
-
-**Changed:**
-
-- Upgraded ADS for Python 3.6-compatibility (no longer supporting Python 2.7)
-- Minor changes to make ADS Windows-compatibile
-- Removed plot hold commands (deprecated)
-
-Version [1.1] - 2018-08-02
--------------------------------------------------------------------------------
-
-**Changed:**
-
-- Minor Mac OSX-related bug fix
-- Changed installation requirements to exact release versions
-
-Version [1.0] - 2018-08-02
--------------------------------------------------------------------------------
-
-Versions 1.x will remain Python 2.7-compatible
-
-Version [0.6] - 2018-08-01
--------------------------------------------------------------------------------
-
-(version 0.5 was skipped due to conflicting file on PyPI)
-
-**Added:**
-
-- Comprehensive testing suite
-- Bug tracking (Sentry)
-- Blue-red visualisation function for segmented masks
-
-**Changed:**
-
-- Dataset building and training notebook
-- Minor documentation improvements
-- Minor bug fixes
-
-Version [0.4.1] - 2018-05-16
--------------------------------------------------------------------------------
-
-**Added:**
-
-- GIMP procedure for ground truth labelling or segmentation correction added in the documentation.
-- Compatibility with tiff images.
-- Continuous integration with Travis is now supported.
-
-**Changed:**
-
-- The documentation website is now hosted on ReadTheDocs.
-- Updated documentation on the usage of AxonDeepSeg.
-- Change of axon and myelin masks filenames for better clarity.
-
-Version [0.3] - 2018-02-22
--------------------------------------------------------------------------------
-
-**Added:**
-
-- Compatibility for image inputs other than png
-- Pre-processing of input images is now done inside AxonDeepSeg
-
-**Changed:**
-
-- Help display when running AxonDeepSeg from terminal
-
 Installation
 ===============================================================================
 The following sections will help you install all the tools you need to run AxonDeepSeg.
@@ -445,6 +355,8 @@ Citation
 If you use this work in your research, please cite:
 
 Zaimi, A., Wabartha, M., Herman, V., Antonsanti, P.-L., Perone, C. S., & Cohen-Adad, J. (2018). AxonDeepSeg: automatic axon and myelin segmentation from microscopy data using convolutional neural networks. Scientific Reports, 8(1), 3816. `Link to the paper <https://doi.org/10.1038/s41598-018-22181-4>`_.
+
+.. include:: ../../CHANGELOG.md
 
 Licensing
 ===============================================================================

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6


### PR DESCRIPTION
Changes:
* Removes hardcoded changelog in RTD
* Converts the CHANGELOG.md to a RTD-compatible syntax
* Fixes the RTD build (which has been broken for a few days) by adding a readthedocs.yml file which enforces a Python 3.6 version during the RTD build.

Check out the final RTD build of this branch here:  https://axondeepseg.readthedocs.io/en/changelog/documentation.html#