### PR TITLE
[GUI] Add buton to compute and save morphometrics

### DIFF
--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -45,7 +45,7 @@ def get_pixelsize(path_pixelsize_file):
         return pixelsize
 
 
-def get_axon_morphometrics(im_axon, path_folder, im_myelin=None):
+def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size=None):
     """
     Find each axon and compute axon-wise morphometric data, e.g., equivalent diameter, eccentricity, etc.
     If a mask of myelin is provided, also compute myelin-related metrics (myelin thickness, g-ratio, etc.).
@@ -54,11 +54,14 @@ def get_axon_morphometrics(im_axon, path_folder, im_myelin=None):
     :param im_myelin: Array: myelin binary mask, output of axondeepseg
     :return: Array(dict): dictionaries containing morphometric results for each axon
     """
-    
-    # If string, convert to Path objects
-    path_folder = convert_path(path_folder)
+    if path_folder is not None:
+        # If string, convert to Path objects
+        path_folder = convert_path(path_folder)
 
-    pixelsize = get_pixelsize(path_folder / 'pixel_size_in_micrometer.txt')
+        pixelsize = get_pixelsize(path_folder / 'pixel_size_in_micrometer.txt')
+
+    if (pixel_size  is not None) and (path_folder is None ):
+        pixelsize = pixel_size
 
     stats_array = np.empty(0)
     # Label each axon object

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ Keras==2.2.4
 Keras-Applications==1.0.8
 Keras-Preprocessing==1.1.0
 opencv-contrib-python==4.1.0.25
+openpyxl==2.6.3


### PR DESCRIPTION
This branch adds a button in the FSLeyes GUI to compute and save morphometrics from a segmented image.

**Workflow**

After you've loaded and segmented an image using the ADS prediction model, you click the new "Compute morphometrics" button here:

<img width="207" alt="Capture d’écran 2019-09-06 à 14 34 05" src="https://user-images.githubusercontent.com/1421029/64446737-29790b00-d0b4-11e9-81ed-b0c8610c301b.png">

which will compute the morphometrics for each axon. After that's done (a few seconds), a popup window will appear for you to select where to save the Excel file containing these data, and to name it:

<img width="1286" alt="Capture d’écran 2019-09-06 à 14 36 17" src="https://user-images.githubusercontent.com/1421029/64446809-53323200-d0b4-11e9-9dc4-06e03f9a9fdd.png">

You can then double click the file after it's saved:

<img width="760" alt="Capture d’écran 2019-09-06 à 14 36 51" src="https://user-images.githubusercontent.com/1421029/64446824-5f1df400-d0b4-11e9-9277-55e4a55649a1.png">

And view the table of morphometrics data for this image:

<img width="948" alt="Capture d’écran 2019-09-06 à 14 37 17" src="https://user-images.githubusercontent.com/1421029/64446837-6ba24c80-d0b4-11e9-8321-3776b62366c8.png">
