### PR TITLE
[Doc] Add notice about restarting FSLeyes to see the plugin for installation

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -205,6 +205,10 @@ On the FSLeyes interface, select ``file -> load plugin -> select ads_plugin.py (
 
 The plugin is now installed. From now on, you can access the plugin on the FSLeyes interface by selecting ``Settings -> Ortho View -> ADScontrol``.
 
+.. NOTE :: For some users, the ADScontrol tab will not appear after first installing the plugin.
+           To resolve this issue, please close FSLeyes and relaunch it (within your virtual environment).
+           This step may only be required when you first install the plugin.
+
 Linux (tested on ubuntu)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Install the C/C++ compilers required to use wxPython ::


### PR DESCRIPTION
Compiled ReadTheDocs branch displaying the change: https://axondeepseg.readthedocs.io/en/fsleyes_restart_bug/documentation.html#graphical-user-interface-gui-optional