### PR TITLE
Fix redownloading models bug

### DIFF
--- a/AxonDeepSeg/models/download_model.py
+++ b/AxonDeepSeg/models/download_model.py
@@ -1,8 +1,17 @@
-from AxonDeepSeg.ads_utils import download_data
+from AxonDeepSeg.ads_utils import *
+from pathlib import Path
 import shutil
 
 
-def main():
+def download_model(destination = None):
+    if destination is None:
+        sem_destination = Path("AxonDeepSeg/models/default_SEM_model")
+        tem_destination = Path("AxonDeepSeg/models/default_TEM_model")
+    else:
+        destination = convert_path(destination)
+        sem_destination = destination / "default_SEM_model"
+        tem_destination = destination / "default_TEM_model"
+
     url_TEM_model = "https://osf.io/2hcfv/?action=download&version=4"  # URL of TEM model hosted on OSF storage with the appropriate versioning on OSF
     url_SEM_model = "https://osf.io/sv7u2/?action=download&version=4"  # URL of SEM model hosted on OSF storage with the appropriate versioning on OSF
 
@@ -14,10 +23,17 @@ def main():
         print(
             "ERROR: Data was not succesfully downloaded and unzipped- please check your link and filename and try again."
         )
-    shutil.move("default_SEM_model", "AxonDeepSeg/models/default_SEM_model")
-    shutil.move("default_TEM_model", "AxonDeepSeg/models/default_TEM_model")
+
+    if sem_destination.exists():
+        print('SEM model folder already existed - deleting old one.')
+        shutil.rmtree(str(sem_destination))
+    if tem_destination.exists():
+        print('TEM model folder already existed - deleting old one.')
+        shutil.rmtree(str(tem_destination))
+
+    shutil.move("default_SEM_model", str(sem_destination))
+    shutil.move("default_TEM_model", str(tem_destination))
 
 
-# Calling the script
-if __name__ == "__main__":
-    main()
+def main(argv=None):
+    download_model()

--- a/test/models/test_download_models.py
+++ b/test/models/test_download_models.py
@@ -48,7 +48,7 @@ class TestCore(object):
             pass
 
     # --------------download_models tests-------------- #
-    @pytest.mark.debug
+    @pytest.mark.unit
     def test_download_models_works(self):
         assert not self.sem_model_path.exists()
         assert not self.tem_model_path.exists()
@@ -59,7 +59,7 @@ class TestCore(object):
         assert self.sem_model_path.exists()
         assert self.tem_model_path.exists()
 
-    @pytest.mark.debug
+    @pytest.mark.unit
     def test_redownload_models_multiple_times_works(self):
 
         download_model(self.tmpPath)

--- a/test/models/test_download_models.py
+++ b/test/models/test_download_models.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+
+from pathlib import Path
+import shutil
+
+import pytest
+
+from AxonDeepSeg.models.download_model import *
+
+
+class TestCore(object):
+    def setup(self):
+        # Get the directory where this current file is saved
+        self.fullPath = Path(__file__).resolve().parent
+        print(self.fullPath)
+        # Move up to the test directory, "test/"
+        self.testPath = self.fullPath.parent 
+        
+        # Create temp folder
+        # Get the directory where this current file is saved
+        self.tmpPath = self.testPath / '__tmp__'
+        if not self.tmpPath.exists():
+            self.tmpPath.mkdir()
+        print(self.tmpPath)
+
+        self.sem_model_path = (
+            self.tmpPath /
+            'default_SEM_model'
+            )
+        print(self.sem_model_path)
+
+        self.tem_model_path = (
+            self.tmpPath /
+            'default_TEM_model'
+            )
+
+    def teardown(self):
+        # Get the directory where this current file is saved
+        fullPath = Path(__file__).resolve().parent
+        print(fullPath)
+        # Move up to the test directory, "test/"
+        testPath = fullPath.parent 
+        tmpPath = testPath / '__tmp__'
+
+        
+        if tmpPath.exists():
+            shutil.rmtree(tmpPath)
+            pass
+
+    # --------------download_models tests-------------- #
+    @pytest.mark.debug
+    def test_download_models_works(self):
+        assert not self.sem_model_path.exists()
+        assert not self.tem_model_path.exists()
+        print(self.sem_model_path.absolute())
+
+        download_model(self.tmpPath)
+
+        assert self.sem_model_path.exists()
+        assert self.tem_model_path.exists()
+
+    @pytest.mark.debug
+    def test_redownload_models_multiple_times_works(self):
+
+        download_model(self.tmpPath)
+        download_model(self.tmpPath)

--- a/test/test_config_tools.py
+++ b/test/test_config_tools.py
@@ -76,7 +76,6 @@ class TestCore(object):
         tmpPath = fullPath / '__tmp__'
         if tmpPath.exists():
             shutil.rmtree(tmpPath)
-        pass
 
     # --------------validate_config tests-------------- #
     @pytest.mark.unit


### PR DESCRIPTION
Resolves #316 and #286

* If model folders already exists, deletes them before moving downloaded ones there
* Adds optional destination input to download_models
* Removed unused __main__ and renamed download_models function.
* Wrote tests for download_models.py (both basic and redownloading behaviour)
* Cleaned up a file that had an unused `pass` call.