### PR TITLE
Add resampled_resolutions parameter in getting_started notebook

### DIFF
--- a/notebooks/00-getting_started.ipynb
+++ b/notebooks/00-getting_started.ipynb
@@ -189,7 +189,7 @@
    "source": [
     "**2.2. Launch the segmentation of the image.**\n",
     "\n",
-    "Here, we launch the segmentation. Here, we specify the following inputs in the *axon_segmentation* function: (i) the path of the image, (ii) the name of the image, (iii) the path of the model, (iv) the configuration json file of the model and (v) the verbosity level. Note that more parameters are available (see description of the *axon_segmentation* function in the code repository).\n",
+    "Here, we launch the segmentation. Here, we specify the following inputs in the *axon_segmentation* function: (i) the path of the image, (ii) the name of the image, (iii) the path of the model, (iv) the configuration json file of the model (v) the target resolution (resampled_resolutions) and (vi) the verbosity level. The target resolution of the current version of the models are 0.1 for the **'default_SEM_model'** and 0.01 for the **'default_TEM_model'**. In this case, our test sample is a SEM spinal cord sample of the rat, so we set resampled_resolutions to 0.1. Note that more parameters are available (see description of the *axon_segmentation* function in the code repository).\n",
     "\n",
     "The output here will be the predicted image, which consists of a 3-label mask (background=0, myelin=127, axon=255). By default, the output prediction will be saved in the same directory as the input image, and named **'AxonDeepSeg.png'**."
    ]
@@ -225,7 +225,7 @@
     }
    ],
    "source": [
-    "prediction = axon_segmentation([path_testing], [\"image.png\"], path_model, config_network,verbosity_level=3)"
+    "prediction = axon_segmentation([path_testing], [\"image.png\"], path_model, config_network, resampled_resolutions=0.1, verbosity_level=3)"
    ]
   },
   {
@@ -476,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #324 

- Added `resampled_resolutions` parameter in `axon_segmentation` function in section 2.2 of `00-getting_started.ipynb`.
- Added description of the parameter for the user.