### PR TITLE
Remove overlap when saving masks

### DIFF
--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -57,3 +57,28 @@ def floodfill_axons(axon_array, myelin_array):
     )
     axon_extracted_array = axon_extracted_array.astype(np.uint8)
     return axon_extracted_array
+
+def remove_intersection(mask_1, mask_2, priority=1):
+    """
+    This function removes the overlap between two masks on one of those two masks depending on the priority parameter.
+    :param mask_1: First mask, with an intersecting section with the sectond one
+    :param mask_2: Second mask, with an intersecting section with the first one
+    :param priority: Tells which of the two arrays should be kept. Can only be 1 or 2.
+    :type priority: int
+    :return split_mask_1: First mask, minus the intersection if it doesn't have priority
+    :return split_mask_2: Sectond mask, minus the intersection if it doesn't have priority
+    """
+
+    if priority not in [1, 2]:
+        raise Exception("Parameter priority can only be 1 or 2")
+
+    array_1 = mask_1.astype(np.bool)
+    array_2 = mask_2.astype(np.bool)
+    intersection = (array_1 & array_2).astype(np.uint8)
+
+    if priority is 1:
+        mask_2 = mask_2 - intersection
+    if priority is 2:
+        mask_1 = mask_1 - intersection
+
+    return mask_1, mask_2

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -58,15 +58,20 @@ def floodfill_axons(axon_array, myelin_array):
     axon_extracted_array = axon_extracted_array.astype(np.uint8)
     return axon_extracted_array
 
-def remove_intersection(mask_1, mask_2, priority=1):
+def remove_intersection(mask_1, mask_2, priority=1, return_overlap=False):
     """
     This function removes the overlap between two masks on one of those two masks depending on the priority parameter.
-    :param mask_1: First mask, with an intersecting section with the sectond one
-    :param mask_2: Second mask, with an intersecting section with the first one
-    :param priority: Tells which of the two arrays should be kept. Can only be 1 or 2.
+    :param mask_1: First mask, with an intersecting section with the sectond one. The mask must contain values of 1 or 0
+    only.
+    :param mask_2: Second mask, with an intersecting section with the first one. The mask must contain values of 1 or 0
+    only.
+    :param priority (optional): Tells which of the two arrays should be kept. Can only be 1 or 2.
     :type priority: int
+    :param return_overlap (optional): If set to True, the overlap mask will be returned.
+    :type return_overlap: bool
     :return split_mask_1: First mask, minus the intersection if it doesn't have priority
     :return split_mask_2: Sectond mask, minus the intersection if it doesn't have priority
+    :return return_overlap: A mask corresponding to the intersection of the two masks
     """
 
     if priority not in [1, 2]:
@@ -81,4 +86,7 @@ def remove_intersection(mask_1, mask_2, priority=1):
     if priority is 2:
         mask_1 = mask_1 - intersection
 
-    return mask_1, mask_2
+    if return_overlap is True:
+        return mask_1, mask_2, intersection
+    else:
+        return mask_1, mask_2

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -400,12 +400,12 @@ class ADScontrol(ctrlpanel.ControlPanel):
         # Note 2 : The image array loaded in FSLeyes is flipped. We need to flip it back
 
         myelin_array = np.array(
-            myelin_mask_overlay[:, :, 0] * params.intensity['binary'], copy=True, dtype=np.uint8
+            myelin_mask_overlay[:, :, 0], copy=True, dtype=np.uint8
         )
         myelin_array = np.flipud(myelin_array)
         myelin_array = np.rot90(myelin_array, k=1, axes=(1, 0))
         axon_array = np.array(
-            axon_mask_overlay[:, :, 0] * params.intensity['binary'], copy=True, dtype=np.uint8
+            axon_mask_overlay[:, :, 0], copy=True, dtype=np.uint8
         )
         axon_array = np.flipud(axon_array)
         axon_array = np.rot90(axon_array, k=1, axes=(1, 0))
@@ -414,6 +414,13 @@ class ADScontrol(ctrlpanel.ControlPanel):
         if myelin_array.shape != axon_array.shape:
             self.show_message("invalid visible masks dimensions")
             return
+
+        # Remove the intersection
+        myelin_array, axon_array = postprocessing.remove_intersection(myelin_array, axon_array, priority=1)
+
+        # Scale the pixel values of the masks to 255 for image saving
+        myelin_array = myelin_array * params.intensity['binary']
+        axon_array = axon_array * params.intensity['binary']
 
         # Save the arrays as PNG files
         myelin_and_axon_array = (myelin_array // 2 + axon_array).astype(np.uint8)

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -416,7 +416,12 @@ class ADScontrol(ctrlpanel.ControlPanel):
             return
 
         # Remove the intersection
-        myelin_array, axon_array = postprocessing.remove_intersection(myelin_array, axon_array, priority=1)
+        myelin_array, axon_array, intersection = postprocessing.remove_intersection(
+            myelin_array, axon_array, priority=1, return_overlap=True)
+
+        if intersection.sum() > 0:
+            self.show_message(
+                "There is an overlap between the axon mask and the myelin mask. The myelin will have priority.")
 
         # Scale the pixel values of the masks to 255 for image saving
         myelin_array = myelin_array * params.intensity['binary']


### PR DESCRIPTION
fixes #321 

ADDED: 
- If there's an overlap between the axon an the myelin mask, the myelin will have priority.
- A popup message in FSLeyes is displayed if there’s an overlap between the Axon mask and the Myelin mask to let the user know Myelin will have priority.