### PR TITLE
Add warning to doc for re-download of model folders when re-installing

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -145,7 +145,7 @@ instruction above::
         pip install -e .
 
 .. WARNING ::
-   When re-installing the application, the ``default_SEM_model`` and ``default_TEM_model`` folders in ``AxonDeepSeg/models`` will be deleted and re-downloaded, make sure to not store valuable data in these folders.
+   When re-installing the application, the ``default_SEM_model`` and ``default_TEM_model`` folders in ``AxonDeepSeg/models`` will be deleted and re-downloaded. Please do not store valuable data in these folders.
 
 Testing the installation
 ------------------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -144,6 +144,8 @@ instruction above::
         git pull
         pip install -e .
 
+.. WARNING ::
+   When re-installing the application, the ``default_SEM_model`` and ``default_TEM_model`` folders in ``AxonDeepSeg/models`` will be deleted and re-downloaded, make sure to not store valuable data in these folders.
 
 Testing the installation
 ------------------------


### PR DESCRIPTION
Updated documentation to add a warning about the re-download of default model folders when re-installing ADS.