### PR TITLE
FSLeyes plugin: default morphometrics file extension and font size 

### DIFF
--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -94,7 +94,7 @@ def remove_intersection(mask_1, mask_2, priority=1, return_overlap=False):
     else:
         return mask_1, mask_2
 
-def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size):
+def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size, mean_axon_diameter_in_pixels=None):
     """
     This function generates an image where the numbers in centroid_index are at their corresponding location specified
     by their coordinates (x0, y0)
@@ -106,6 +106,9 @@ def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size):
     :type y0_array: numpy array
     :param image_size: the size of the image
     :type image_size: tuple
+    :param mean_axon_diameter_in_pixels (optional): the mean axon diameter of the axon mask. If this parameter
+    is passed, the font size will be determined based on it. Otherwise, the image size will be used to determine
+    the font size.
     :return: the binary image with the numbers at their corresponding coordinate.
     """
 
@@ -115,8 +118,12 @@ def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size):
 
     # Use a font from the matplotlib package
     # The size of the font depends on the dimensions of the image, should be at least 10
+    # If the the mean_axon_diameter is specified, use it to determine the font_size
     font_path = os.path.join(rcParams["datapath"], "fonts/ttf/DejaVuSans.ttf")
-    font_size = max(int(sum(image_size) * 0.5 * 0.01), 10)
+    if mean_axon_diameter_in_pixels is None:
+        font_size = max(int(sum(image_size) * 0.5 * 0.01), 10)
+    else:
+        font_size = max(int(mean_axon_diameter_in_pixels / 3), 10)
     font = ImageFont.truetype(font=font_path, size=font_size)
 
     # Fill the image with the numbers at their corresponding coordinates

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -35,7 +35,7 @@ import imageio
 
 from AxonDeepSeg.morphometrics.compute_morphometrics import *
 
-VERSION = "0.2.13"
+VERSION = "0.2.14"
 
 class ADScontrol(ctrlpanel.ControlPanel):
     """
@@ -161,7 +161,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 "Calculates and saves the morphometrics to an excel and csv file. "
                 "Shows the numbers of the axons at the coordinates specified in the morphometrics file."
             )
-        ) 
+        )
         sizer_h.Add(compute_morphometrics_button, flag=wx.SHAPED, proportion=1)
 
         # Set the sizer of the control panel
@@ -615,6 +615,8 @@ class ADScontrol(ctrlpanel.ControlPanel):
 
             # save the current contents in the file
             pathname = fileDialog.GetPath()
+            if not (pathname.lower().endswith((".xlsx", ".csv"))):  # If the user didn't add the extension, add it here
+                pathname = pathname + ".xlsx"
             try:
                 # Export to excel
                 pd.DataFrame(x).to_excel(pathname)
@@ -623,9 +625,11 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 wx.LogError("Cannot save current data in file '%s'." % pathname)
 
         # Create the axon coordinate array
+        mean_diameter_in_pixel = np.average(x['axon_diam']) / pixel_size
         axon_indexes = np.arange(x.size)
         number_array = postprocessing.generate_axon_numbers_image(axon_indexes, x['x0'], x['y0'],
-                                                                  tuple(reversed(axon_array.shape)))
+                                                                  tuple(reversed(axon_array.shape)),
+                                                                  mean_diameter_in_pixel)
 
         # Load the axon coordinate image into FSLeyes
         number_outfile = self.ads_temp_dir.name + "/numbers.png"


### PR DESCRIPTION
Changes:
- A default extension (.xlsx) is added to the morphometrics file if the user didn't specify any.
- The font size of the numbers overlay is determined based on the mean axon diameter (in pixels, not in micrometers)