### PR TITLE
Fix for the Windows installation

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -209,8 +209,8 @@ def download_data(url_data):
             # Unzip
             print("Unzip...")
             try:
-                zf = zipfile.ZipFile(str(tmp_path))
-                zf.extractall(".")
+                with zipfile.ZipFile(str(tmp_path)) as zf:
+                    zf.extractall(".")
             except (zipfile.BadZipfile):
                 print('ERROR: ZIP package corrupted. Please try downloading again.')
                 return 1


### PR DESCRIPTION
This PR fixes #361 

For some reason, those two lines in `ads_utils.download_data()` wouldn't work on Windows during the installation:
```
zf = zipfile.ZipFile(str(tmp_path))
zf.extractall(".")
```
I changed them to
```
with zipfile.ZipFile(str(tmp_path)) as zf:
	zf.extractall(".")
```
