### PR TITLE
Resolve bug that makes TEM data not segment well with multiple files

### DIFF
--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -159,10 +159,7 @@ def segment_folders(path_testing_images_folder, path_model,
 
         img_name_original = file_.stem
 
-        if selected_model == "default_TEM_model":
-            ads.imwrite(fp,255-img, format='png')
-        else:
-            ads.imwrite(fp,img, format='png')
+        ads.imwrite(fp,img, format='png')
 
         acquisition_name = Path(fp.name).name
         segmented_image_name = img_name_original + '_seg-axonmyelin' + '.png'

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -159,7 +159,7 @@ def segment_folders(path_testing_images_folder, path_model,
 
         img_name_original = file_.stem
 
-        ads.imwrite(fp,img, format='png')
+        ads.imwrite(fp, img, format='png')
 
         acquisition_name = Path(fp.name).name
         segmented_image_name = img_name_original + '_seg-axonmyelin' + '.png'


### PR DESCRIPTION
Fixes #369 

TEM image contrasts are no longer inverted when using CLI pointing on a folder with multiple files.
