### PR TITLE
Fix new changelog display in RTD

### DIFF
--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,8 +39,7 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,9 @@ import AxonDeepSeg
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.githubpages']
+extensions = [
+	'sphinx.ext.githubpages',
+	'recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -462,33 +462,3 @@ If you use this work in your research, please cite:
 Zaimi, A., Wabartha, M., Herman, V., Antonsanti, P.-L., Perone, C. S., & Cohen-Adad, J. (2018). AxonDeepSeg: automatic axon and myelin segmentation from microscopy data using convolutional neural networks. Scientific Reports, 8(1), 3816. `Link to the paper <https://doi.org/10.1038/s41598-018-22181-4>`_.
 
 .. include:: ../../CHANGELOG.md
-
-Licensing
-=========
-
-The MIT License (MIT)
-
-Copyright (c) 2018 NeuroPoly, École Polytechnique, Université de Montréal
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-Contributors
-============
-
-Pierre-Louis Antonsanti, Mathieu Boudreau, Oumayma Bounou, Julien Cohen-Adad, Victor Herman, Melanie Lubrano, Christian Perone, Maxime Wabartha, Aldo Zaimi, Vasudev Sharma, Stoyan Asenov, Marie-Hélène Bourget.

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -460,5 +460,3 @@ Citation
 If you use this work in your research, please cite:
 
 Zaimi, A., Wabartha, M., Herman, V., Antonsanti, P.-L., Perone, C. S., & Cohen-Adad, J. (2018). AxonDeepSeg: automatic axon and myelin segmentation from microscopy data using convolutional neural networks. Scientific Reports, 8(1), 3816. `Link to the paper <https://doi.org/10.1038/s41598-018-22181-4>`_.
-
-.. include:: ../../CHANGELOG.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,6 +51,8 @@ AxonDeepSeg is a segmentation software for microscopy data of nerve fibers. It i
    :caption: Contents:
 
    documentation.rst
+   CHANGELOG.md
+   license_contributors.rst
 
 
 Indices and tables

--- a/docs/source/license_contributors.rst
+++ b/docs/source/license_contributors.rst
@@ -1,0 +1,29 @@
+Licensing
+=========
+
+The MIT License (MIT)
+
+Copyright (c) 2018 NeuroPoly, École Polytechnique, Université de Montréal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Contributors
+============
+
+Pierre-Louis Antonsanti, Mathieu Boudreau, Oumayma Bounou, Julien Cohen-Adad, Victor Herman, Melanie Lubrano, Christian Perone, Maxime Wabartha, Aldo Zaimi, Vasudev Sharma, Stoyan Asenov, Marie-Hélène Bourget.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
     },
     extras_require={
         'docs': ['sphinx>=1.6',
-                 'sphinx_rtd_theme>=0.2.4'],
+                 'sphinx_rtd_theme>=0.2.4',
+                 'recommonmark'],
     },
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
Fixes #367 
Added symlink to CHANGELOG.md in `docs/source` and requirement `recommonmark` in `conf.py` and `setup.py` to be able to display markdown properly.

Previous documentation was all on the same page, here I had to split the documentation in 3 sections (3 pages) in `index.rst` to display the markdown symlink correctly:
- Before CHANGLOG on one page (Introduction to Citation)
- CHANGELOG
- After CHANGELOG (Licensing and Contributors)

Docs is rendered here: https://axondeepseg.readthedocs.io/en/mhb-367-fix-changelog/

@jcohenadad, is the split in 3 parts ok with you? I could also split each section in individual pages like it is done for [ivadomed](https://ivadomed.org/en/latest/index.html) or [SCT](https://spinalcordtoolbox.com/en/stable/index.html).

