### PR TITLE
Bug fix due to h5py package version in fsleyes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
       os: linux
       script: 
         - yes | conda install -c conda-forge fsleyes=0.33.1
+        - yes | conda install -c conda-forge h5py=2.10.0
         - py.test . -v --cov AxonDeepSeg/ --cov-report term-missing
     - stage: Basic install
       os: osx
@@ -33,6 +34,7 @@ jobs:
       os: osx
       script: 
         - yes | conda install -c conda-forge fsleyes=0.33.1
+        - yes | conda install -c conda-forge h5py=2.10.0
         - py.test . -v --cov AxonDeepSeg/ --cov-report term-missing
 after_success:
   - coveralls

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -176,6 +176,10 @@ Install FSLeyes using conda-forge ::
 
            yes | conda install -c conda-forge fsleyes=0.33.1
 
+Downgrade from latest version of h5py to the most recent working version ::
+
+           yes | conda install -c conda-forge h5py=2.10.0
+
 Launch FSLeyes ::
 
            fsleyes
@@ -211,6 +215,10 @@ Install wxPython using conda ::
 Install FSLeyes using conda-forge ::
 
            yes | conda install -c conda-forge fsleyes=0.33.1
+
+Downgrade from latest version of h5py to the most recent working version ::
+
+           yes | conda install -c conda-forge h5py=2.10.0
 
 Launch FSLeyes ::
 


### PR DESCRIPTION
Related to #390 and #382.

Added downgrade to `h5py=2.10.0` after fsleyes installation in documentation and travis tests to avoid errors in `training_network.py` and `test_training_network.py`.

Tested on Linux.
All tests passed locally except `test_floodfill_axons_returns_expected_arrays` from `test_postprocessing.py`, as mentioned in #390 (unrelated to h5py and passing on travis).
