### PR TITLE
[Doc] Update installation and software update instructions

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -126,10 +126,6 @@ AxonDeepSeg package with the following commands::
         git pull
         pip install -e .
         
-If you are using the FSLeyes GUI, you should update FSLeyes as well to make sure it uses the required packages: ::
-
-    yes | conda install -c conda-forge fsleyes=0.33.1
-    yes | conda install -c conda-forge h5py=2.10.0
 
 .. WARNING ::
    When re-installing the application, the ``default_SEM_model`` and ``default_TEM_model`` folders in ``AxonDeepSeg/models`` will be deleted and re-downloaded. Please do not store valuable data in these folders.

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -200,18 +200,8 @@ In case, you find trouble installing FSLeyes plugin for ADS you could refer the 
            To resolve this issue, please close FSLeyes and relaunch it (within your virtual environment).
            This step may only be required when you first install the plugin.
 
-Linux (tested on ubuntu)
+Linux (tested on Ubuntu 20.04)
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Install the C/C++ compilers required to use wxPython ::
-
-           sudo apt-get install build-essential
-           sudo apt-get install libgtk2.0-dev libgtk-3-dev libwebkitgtk-dev libwebkitgtk-3.0-dev
-           sudo apt-get install libjpeg-turbo8-dev libtiff5-dev libsdl1.2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libnotify-dev freeglut3-dev
-           
-Install wxPython using conda ::
-
-           yes | conda install -c anaconda wxpython
-           
 Install FSLeyes using conda-forge ::
 
            yes | conda install -c conda-forge fsleyes=0.33.1

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -125,6 +125,11 @@ AxonDeepSeg package with the following commands::
         cd axondeepseg
         git pull
         pip install -e .
+        
+If you are using the FSLeyes GUI, you should update FSLeyes as well to make sure it uses the required packages: ::
+
+    yes | conda install -c conda-forge fsleyes=0.33.1
+    yes | conda install -c conda-forge h5py=2.10.0
 
 .. WARNING ::
    When re-installing the application, the ``default_SEM_model`` and ``default_TEM_model`` folders in ``AxonDeepSeg/models`` will be deleted and re-downloaded. Please do not store valuable data in these folders.


### PR DESCRIPTION
fixes #393 

Possibly fixes #343 as well

Parts of the documentation for the Linux installation have been removed because they are no longer required.

For details, check #393 