### PR TITLE
Fill the myelin with the "remove_small_holes" tool

### DIFF
--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -135,3 +135,24 @@ def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size, 
     image_array = np.asarray(number_image)
 
     return image_array.astype(np.uint8)
+
+def fill_myelin_holes(myelin_array):
+    """
+    This function uses the fill_small_holes function from scikit-image to fill closed myelin objects with the axon mask.
+    The maximum area of an axon is defined as 10% of the image's size.
+    :param myelin_array: the binary array corresponding to the myelin mask
+    :return: the binary axon array corresponding to the axon mask after the floodfill
+    """
+    # Get the dimensions of the image
+    image_dims = myelin_array.shape
+
+    # Define the maximum axon area as 10% of the image's size
+    maximum_axon_area = 0.1 * image_dims[0] * image_dims[1]
+
+    #Fill the myelin array
+    filled_array = morphology.remove_small_holes(myelin_array.astype(np.bool), area_threshold=maximum_axon_area)
+    filled_array = filled_array.astype(np.uint8)
+
+    #Extract the axon array
+    axon_extracted_array = filled_array-myelin_array
+    return axon_extracted_array

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -35,7 +35,7 @@ import imageio
 
 from AxonDeepSeg.morphometrics.compute_morphometrics import *
 
-VERSION = "0.2.14"
+VERSION = "0.2.15"
 
 class ADScontrol(ctrlpanel.ControlPanel):
     """
@@ -494,19 +494,15 @@ class ADScontrol(ctrlpanel.ControlPanel):
         """
         # Find the visible myelin and axon mask
         myelin_mask_overlay = self.get_visible_myelin_overlay()
-        axon_mask_overlay = self.get_visible_axon_overlay()
 
         if myelin_mask_overlay is None:
-            return
-        if axon_mask_overlay is None:
             return
 
         # Extract the data from the overlays
         myelin_array = myelin_mask_overlay[:, :, 0]
-        axon_array = axon_mask_overlay[:, :, 0]
 
         # Perform the floodfill operation
-        axon_extracted_array = postprocessing.floodfill_axons(axon_array, myelin_array)
+        axon_extracted_array = postprocessing.fill_myelin_holes(myelin_array)
 
         axon_corr_array = np.flipud(axon_extracted_array)
         axon_corr_array = params.intensity['binary'] * np.rot90(axon_corr_array, k=1, axes=(1, 0))


### PR DESCRIPTION
Check this presentation for more information on the tool: https://docs.google.com/presentation/d/1aRl7C1IzzdhXzUBHk4tnIzU3L2r-DJ1540hnQdivzJE/edit#slide=id.p

Fixes #401 and #384.

This is an alternative to #397 and #400.

The limits of this tool will be axons which have a very large area (more than 10% of the image's size, we can ajust this) and images in which the background represents a very small area (less than 10% of the image, we can ajust this).