### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jupyter/datascience-notebook:python-3.7.6
+
+USER root
+
+RUN cd $HOME/work;\
+    git clone https://github.com/neuropoly/axondeepseg.git; \
+    cd axondeepseg; \
+    pip install -e . ; \
+    chmod -R 777 $HOME/work/axondeepseg;
+
+WORKDIR $HOME/work/axondeepseg
+
+USER $NB_UID

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ opencv-contrib-python==4.1.0.25
 albumentations==0.3.0
 openpyxl==2.6.3
 h5py~=2.10.0
-opencv-python-headless==4.4.0.44
+opencv-python-headless==4.4.0.44 


### PR DESCRIPTION
The current installation for MyBinder/Docker depends on the requirements.txt/setup.py file, however I think that `repo2docker` doesn't use the editable mode during the pip installation of our package (i.e. `pip install -e .`) and I haven't been able to find an option to do so. This is required to download the model in the repository of our cloned software; otherwise the models will be missing per my mention in the discussion of #413 .

This PR resolves this issue by using a Dockerfile that overrides the requirements.txt/setup.py installation that repo2docker does, and in it I explicitely clone the master branch of the repository and run `pip install -e .`. The only downside is that it does not automatically rebuild on MyBinder unless there has been a modification in the Dockerfile after a version has been cached, so we may have to periodically update the file to force rebuilds.

Test it here: https://mybinder.org/v2/gh/neuropoly/axondeepseg/mybinder_debug