### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Checklist
+
+- [ ] I've given this PR a concise, self-descriptive, and meaningful title
+- [ ] I've linked relevant issues in the PR body
+- [ ] I've applied the relevant labels to this PR
+- [ ] I've added relevant tests for my contribution
+- [ ] I've updated the documentation and/or added correct docstrings
+- [ ] I've assigned a reviewer
+
+<!--- For the title, please observe the following rules:
+	- Provide a concise and self-descriptive title
+	- Do not include the applicable issue number in the title, do it in the PR body
+	- If the PR is not ready for review, convert it to a draft.
+-->
+
+## Description
+<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
+
+## Linked issues
+<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,12 @@
 
 - [ ] I've given this PR a concise, self-descriptive, and meaningful title
 - [ ] I've linked relevant issues in the PR body
-- [ ] I've applied the relevant labels to this PR
+- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
 - [ ] I've added relevant tests for my contribution
 - [ ] I've updated the documentation and/or added correct docstrings
 - [ ] I've assigned a reviewer
+- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions
+
 
 <!--- For the title, please observe the following rules:
 	- Provide a concise and self-descriptive title


### PR DESCRIPTION
This PR aims to add a PR template. For context, refer [here](https://github.com/neuropoly/axondeepseg/issues/466).

**PR TEMPLATE** --> https://github.com/neuropoly/axondeepseg/blob/vs/pr_template/.github/pull_request_template.md

**Testing** 
I'm not sure if the PR can be tested before merging into the `master` branch. Though I'm sure that after the PR has been merged, whenever we will create a new PR, a PR template would be added to every new PR. 

One option to test this PR is:
1. First in your forked ADS repo, in the `master` branch, add [this](https://github.com/neuropoly/axondeepseg/blob/vs/pr_template/.github/pull_request_template.md) file. 
2. Now create a PR using any other branch.

A PR template would be observed.

![image](https://user-images.githubusercontent.com/31419210/109393771-aacbf980-7949-11eb-9f37-2d96e19e08a0.png)

Fixes #466 