### PR TITLE
Change the default name for saving the morphometrics file

### DIFF
--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -606,7 +606,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 )
 
         with wx.FileDialog(self, "Save morphometrics file", wildcard="Excel files (*.xlsx)|*.xlsx",
-                       style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT) as fileDialog:
+                        defaultFile="Morphometrics.xlsx", style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT) as fileDialog:
 
             if fileDialog.ShowModal() == wx.ID_CANCEL:
                 return     # the user changed their mind

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -606,7 +606,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 )
 
         with wx.FileDialog(self, "Save morphometrics file", wildcard="Excel files (*.xlsx)|*.xlsx",
-                        defaultFile="Morphometrics.xlsx", style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT) as fileDialog:
+                        defaultFile="axon_morphometrics.xlsx", style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT) as fileDialog:
 
             if fileDialog.ShowModal() == wx.ID_CANCEL:
                 return     # the user changed their mind


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body 
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution (**Kindly manually test this PR**)
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
The default file name for saving the morphometrics file in FSLeyes plugin is `Untitiled.xlsx`. This PR aims to change the default file name to a more intuitive file name such as `axon_morphometrics.xlsx.`

So, now when the morphometrics file is saved using the FSLeyes plugin, the default name would be `axon_morphometrics.xlsx`.

![image](https://user-images.githubusercontent.com/31419210/110207291-8ff90800-7ea8-11eb-85e0-a059b25892c9.png)


## Linked issues
Fixes #465 