### PR TITLE
Change the name of `-o` flag to `-overlap` flag

### DIFF
--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -280,7 +280,7 @@ def main(argv=None):
                                                             '   for the segmentation of current sample. \n'+
                                                             '3: Also displays the patch number being processed in the current sample.',
                                                             default=0)
-    ap.add_argument('-overlap', '--overlap', required=False, type=int, help='Overlap value (in pixels) of the patches when doing the segmentation. \n'+
+    ap.add_argument('--overlap', required=False, type=int, help='Overlap value (in pixels) of the patches when doing the segmentation. \n'+
                                                             'Higher values of overlap can improve the segmentation at patch borders, \n'+
                                                             'but also increase the segmentation time. \n'+
                                                             'Default value: '+str(default_overlap)+'\n'+

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -280,7 +280,7 @@ def main(argv=None):
                                                             '   for the segmentation of current sample. \n'+
                                                             '3: Also displays the patch number being processed in the current sample.',
                                                             default=0)
-    ap.add_argument('-o', '--overlap', required=False, type=int, help='Overlap value (in pixels) of the patches when doing the segmentation. \n'+
+    ap.add_argument('-overlap', '--overlap', required=False, type=int, help='Overlap value (in pixels) of the patches when doing the segmentation. \n'+
                                                             'Higher values of overlap can improve the segmentation at patch borders, \n'+
                                                             'but also increase the segmentation time. \n'+
                                                             'Default value: '+str(default_overlap)+'\n'+

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -263,7 +263,7 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     **2**: Also displays the information about the prediction step for the segmentation of current sample. 
                     **3**: Also displays the patch number being processed in the current sample.
 
--overlap            Overlap value (in pixels) of the patches when doing the segmentation. 
+--overlap            Overlap value (in pixels) of the patches when doing the segmentation. 
                     Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -258,13 +258,13 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     If no pixel size is specified, a **pixel_size_in_micrometer.txt** file needs to be added to the image folder path ( that file should contain a single float number corresponding to the resolution of the image, i.e. the pixel size). The pixel size in that file will be used for the segmentation.
 
 -v VERBOSITY        Verbosity level. 
-                            **0** (default) : Displays the progress bar for the segmentation. 
-                            **1**: Also displays the path of the image(s) being segmented. 
-                            **2**: Also displays the information about the prediction step for the segmentation of current sample. 
-                            **3**: Also displays the patch number being processed in the current sample.
+                    **0** (default) : Displays the progress bar for the segmentation. 
+                    **1**: Also displays the path of the image(s) being segmented. 
+                    **2**: Also displays the information about the prediction step for the segmentation of current sample. 
+                    **3**: Also displays the patch number being processed in the current sample.
 
--overlap                 Overlap value (in pixels) of the patches when doing the segmentation. 
-                         Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
+-overlap            Overlap value (in pixels) of the patches when doing the segmentation. 
+                    Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
    ::

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -258,13 +258,13 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     If no pixel size is specified, a **pixel_size_in_micrometer.txt** file needs to be added to the image folder path ( that file should contain a single float number corresponding to the resolution of the image, i.e. the pixel size). The pixel size in that file will be used for the segmentation.
 
 -v VERBOSITY        Verbosity level. 
-                    **0** (default) : Displays the progress bar for the segmentation. 
-                    **1**: Also displays the path of the image(s) being segmented. 
-                    **2**: Also displays the information about the prediction step for the segmentation of current sample. 
-                    **3**: Also displays the patch number being processed in the current sample.
+                            **0** (default) : Displays the progress bar for the segmentation. 
+                            **1**: Also displays the path of the image(s) being segmented. 
+                            **2**: Also displays the information about the prediction step for the segmentation of current sample. 
+                            **3**: Also displays the patch number being processed in the current sample.
 
--overlap OVERLAP          Overlap value (in pixels) of the patches when doing the segmentation. 
-                    Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
+-overlap                 Overlap value (in pixels) of the patches when doing the segmentation. 
+                         Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
    ::

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -263,7 +263,7 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     **2**: Also displays the information about the prediction step for the segmentation of current sample. 
                     **3**: Also displays the patch number being processed in the current sample.
 
--o OVERLAP          Overlap value (in pixels) of the patches when doing the segmentation. 
+-overlap OVERLAP          Overlap value (in pixels) of the patches when doing the segmentation. 
                     Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -263,7 +263,7 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     **2**: Also displays the information about the prediction step for the segmentation of current sample. 
                     **3**: Also displays the patch number being processed in the current sample.
 
---overlap            Overlap value (in pixels) of the patches when doing the segmentation. 
+--overlap           Overlap value (in pixels) of the patches when doing the segmentation. 
                     Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 25. Recommended range of values: [10-100]. 
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -193,7 +193,7 @@ class TestCore(object):
     def test_main_cli_runs_succesfully_with_valid_inputs_with_overlap_value(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "2", "-s", "0.37", '-overlap', '25'])
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "2", "-s", "0.37", '--overlap', '25'])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
 

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -190,6 +190,14 @@ class TestCore(object):
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
 
     @pytest.mark.integration
+    def test_main_cli_runs_succesfully_with_valid_inputs_with_overlap_value(self):
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "2", "-s", "0.37", '-overlap', '25'])
+
+        assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+
+    @pytest.mark.integration
     def test_main_cli_runs_succesfully_with_valid_inputs_with_pixel_size_file(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
As pointed out by Julien in the issue https://github.com/neuropoly/axondeepseg/issues/460, the `-o` flag for segmenting the images sounds like output, in this PR I've dropped the single dash overlap `-o` flag which is confusing.

## How to test this PR?
1. First, do `pip install -e .` in this branch.
2. Segment an image using changed flag name; `axondeepseg -i <image_name.png> -t <Modality type> --overlap <overlap_value>`

## Changed Documentation of this PR
https://axondeepseg--474.org.readthedocs.build/en/474/documentation.html#syntax

## Linked issues
Fixes #460