### PR TITLE
Change the way the font is found in the postprocessing.py script

### DIFF
--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -5,7 +5,7 @@ from skimage import measure, morphology, feature
 from PIL import Image, ImageDraw, ImageOps, ImageFont
 import numpy as np
 import AxonDeepSeg.params
-from matplotlib import rcParams
+from matplotlib import font_manager
 import os
 
 def get_centroids(mask):
@@ -119,7 +119,7 @@ def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size, 
     # Use a font from the matplotlib package
     # The size of the font depends on the dimensions of the image, should be at least 10
     # If the the mean_axon_diameter is specified, use it to determine the font_size
-    font_path = os.path.join(rcParams["datapath"], "fonts/ttf/DejaVuSans.ttf")
+    font_path = font_manager.findfont("DejaVu Sans")
     if mean_axon_diameter_in_pixels is None:
         font_size = max(int(sum(image_size) * 0.5 * 0.01), 10)
     else:


### PR DESCRIPTION
## Checklist

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


## Description
Currently, the way we search for the font file in [postprocessing.py](https://github.com/neuropoly/axondeepseg/blob/master/AxonDeepSeg/postprocessing.py) doesn't work on newer versions of matplotlib (at least on Windows). This PR proposes a better and more flexible way to search for the font file.

The `FindFont` from `matplotlib.font_manager` function should be more reliable because it returns a default font path even if the one specified is not foud. In our case, it happens that the specified font is the default one.

## Linked issues
Resolves #488 