### PR TITLE
Add tutorial video link in RTD

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -151,7 +151,7 @@ In case, you find trouble installing FSLeyes plugin for ADS you could refer the 
 .. raw:: html
 
    <div style="position: relative; padding-bottom: 5%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-     <iframe width="700" height="394" src="https://www.youtube.com/embed/dz2LqQ5LpIo" frameborder="0" allowfullscreen></iframe>
+     <iframe width="700" height="394" src="https://www.youtube.com/embed/qzWeG5vaVyo" frameborder="0" allowfullscreen></iframe>
 
 
 .. NOTE :: For some users, the ADScontrol tab will not appear after first installing the plugin.

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -146,6 +146,19 @@ In FSLeyes, do the following:
 
 From now on, you can access the plugin on the FSLeyes interface by selecting ``Settings -> Ortho View -> ADScontrol``.
 
+In case, you find trouble installing FSLeyes plugin for ADS you could refer the video below.
+
+.. raw:: html
+
+   <div style="position: relative; padding-bottom: 5%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+     <iframe width="700" height="394" src="https://www.youtube.com/embed/dz2LqQ5LpIo" frameborder="0" allowfullscreen></iframe>
+
+
+.. NOTE :: For some users, the ADScontrol tab will not appear after first installing the plugin.
+           To resolve this issue, please close FSLeyes and relaunch it (within your virtual environment).
+           This step may only be required when you first install the plugin.
+
+
 Known issues
 ~~~~~~~~~~~~
 1. The FSLeyes installation doesn't always work on Linux. Refer to the `FSLeyes installation guide <https://users.fmrib.ox.ac.uk/~paulmc/fsleyes/userdoc/latest/install.html>`_ if you need. In our testing, most issues came from the installation of the wxPython package.


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR add the link to the video tutorial in RTD and the note about the ADScontrol tab not appearing after first installing the plugin. Both were removed by mistake in #452.

## Linked issues
Fixes #492 