### PR TITLE
Fix black bar segmentation bug when width = height

### DIFF
--- a/AxonDeepSeg/patch_management_tools.py
+++ b/AxonDeepSeg/patch_management_tools.py
@@ -99,7 +99,7 @@ def patches2im_overlap(L_patches, L_pos, overlap_value=25, scw=512):
                                                                                                           -overlap_value:,
                                                                                                           overlap_value:-overlap_value]
         if L_pos[i][1] == w_l:
-            if L_pos[i][1] != h_l:
+            if L_pos[i][0] != h_l:
                 new_img[L_pos[i][0] + overlap_value:L_pos[i][0] + scw - overlap_value, -overlap_value:] = e[
                                                                                                           overlap_value:-overlap_value,
                                                                                                           -overlap_value:]


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR fixes a bug where a black bar appears in the segmentation at the right of the image when the image width and height are the same, see #509 for details.

## To test the PR
1. On master branch, segment an image where width=height. For reference, the `Maxo03_img60` image from our SEM dataset is 2001x2001. There will be a black bar on the right in the segmentation.
2. Checkout this branch and redo the segmentation --> no black bar.
3. Segment another image where width != height --> no black bar.

I did not add a test for this fix. As discussed today, we would need to add an integrity test for the prediction first (#508).

## Linked issues
Fixes #509 