### PR TITLE
Doc: Add description of morphometrics columns headings

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -368,7 +368,7 @@ This will generate **'axon_morphometrics.xlsx'** file in each of folders::
 Morphometrics file
 ~~~~~~~~~~~~~~~~~~
 
-The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following columns headings:
+The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following columns headings. Most of the metrics are computed using `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 .. list-table::
    :widths: 20 80
@@ -402,8 +402,6 @@ The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following 
      - Eccentricity of the ellipse that has the same second-moments as the axon region.
    * - orientation
      - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
-
-.. NOTE :: x0, y0, axon_area, axon_perimeter, axon_diameter, axonmyelin_area, axonmyelin_perimeter, solidity, eccentricity and orientation are extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -169,7 +169,7 @@ GPU-compatible installation
 .. NOTE :: This feature is not available if you are using a macOS.
 
 Linux and Windows 10
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 By default, AxonDeepSeg installs the CPU version of TensorFlow. To train a model using your GPU, you need to uninstall the TensorFlow from your virtual environment, and install the GPU version of it::
 
@@ -370,13 +370,12 @@ Morphometrics file
 
 The resulting **'axon_morphometrics'** file will contain the following columns headings:
 
-.. list-table:: axon_morphometrics.csv/xls
+.. list-table:: axon_morphometrics.csv/xlsx
    :widths: 20 80
    :header-rows: 1
 
    * - Field
      - Description
-     - Heading row 1, column 3
    * - x0
      - Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - y0

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -370,44 +370,39 @@ Morphometrics file
 
 The resulting **'axon_morphometrics'** file will contain the following columns headings:
 
-x0
-                    Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+.. list-table:: axon_morphometrics.csv/xls
+   :widths: 20 80
+   :header-rows: 1
 
-y0
-                    Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-gratio
-                    Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
-
-axon_area
-                    Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-axon_perimeter
-                    Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-myelin_area
-                    Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
-
-axon_diameter
-                    Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-myelin_thickness
-                    Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
-
-axonmyelin_area
-                    Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-axonmyelin_perimeter
-                    Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-solidity
-                    Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-eccentricity
-                    Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
-
-orientation
-                    Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - Field
+     - Description
+     - Heading row 1, column 3
+   * - x0
+     - Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - y0
+     - Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - gratio
+     - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
+   * - axon_area
+     - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - axon_perimeter
+     - Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - myelin_area
+     - Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
+   * - axon_diameter
+     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - myelin_thickness
+     - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
+   * - axonmyelin_area
+     - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - axonmyelin_perimeter
+     - Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - solidity
+     - Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - eccentricity
+     - Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+   * - orientation
+     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -377,31 +377,33 @@ The resulting **'axon_morphometrics'** file will contain the following columns h
    * - Field
      - Description
    * - x0
-     - Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Axon X centroid position in pixels.
    * - y0
-     - Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Axon Y centroid position in pixels.
    * - gratio
      - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axon_area
-     - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axon_perimeter
-     - Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Perimeter of the axon object in :math:`{\mu}`\ m.
    * - myelin_area
      - Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axon_diameter
-     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region).
    * - myelin_thickness
      - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axonmyelin_area
-     - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axonmyelin_perimeter
-     - Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m.
    * - solidity
-     - Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Ratio of pixels in the axon region to pixels of the convex hull image.
    * - eccentricity
-     - Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Eccentricity of the ellipse that has the same second-moments as the axon region.
    * - orientation
-     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
+
+.. NOTE :: x0, y0, axon_area, axon_perimeter, axon_diameter, axonmyelin_area, axonmyelin_perimeter, solidity, eccentricity and orientation are extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -359,6 +359,49 @@ This will generate **'axon_morphometrics.xlsx'** file in each of folders::
     ---- pixel_size_in_micrometer.txt
     ---- axon_morphometrics.xlsx
 
+Morphometrics file
+~~~~~~~~~~~~~~~~~~
+
+The resulting **'axon_morphometrics'** file will contain the following columns headings:
+
+x0
+                        | Axon X centroid position in pixels.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+y0
+                        | Axon Y centroid position in pixels.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+gratio
+                        Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
+axon_area
+                        | Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ .
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+axon_perimeter
+                        | Perimeter of the axon object in :math:`{\mu}`\ m.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+myelin_area
+                        Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
+axon_diameter
+                        | Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region).
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+myelin_thickness
+                        Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
+axonmyelin_area
+                        | Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ .
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+axonmyelin_perimeter
+                        | Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+solidity
+                        | Ratio of pixels in the axon region to pixels of the convex hull image.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+eccentricity
+                        | Eccentricity of the ellipse that has the same second-moments as the axon region.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+orientation
+                        | Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
+                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+
+
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -381,7 +381,7 @@ The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following 
    * - y0
      - Axon Y centroid position in pixels.
    * - gratio
-     - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
+     - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter (`gratio = axon_diameter / axonmyelin_diameter`). Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axon_area
      - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axon_perimeter

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -389,7 +389,7 @@ The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following 
    * - myelin_area
      - Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axon_diameter
-     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region).
+     - Equivalent diameter of the axon in :math:`{\mu}`\ m. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - myelin_thickness
      - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axonmyelin_area

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -381,7 +381,7 @@ The resulting **'axon_morphometrics'** file will contain the following columns h
    * - y0
      - Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - gratio
-     - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
+     - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axon_area
      - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - axon_perimeter
@@ -391,7 +391,7 @@ The resulting **'axon_morphometrics'** file will contain the following columns h
    * - axon_diameter
      - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - myelin_thickness
-     - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
+     - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axonmyelin_area
      - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - axonmyelin_perimeter

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -368,9 +368,9 @@ This will generate **'axon_morphometrics.xlsx'** file in each of folders::
 Morphometrics file
 ~~~~~~~~~~~~~~~~~~
 
-The resulting **'axon_morphometrics'** file will contain the following columns headings:
+The resulting **'axon_morphometrics.csv/xlsx'** file will contain the following columns headings:
 
-.. list-table:: axon_morphometrics.csv/xlsx
+.. list-table::
    :widths: 20 80
    :header-rows: 1
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -365,43 +365,43 @@ Morphometrics file
 The resulting **'axon_morphometrics'** file will contain the following columns headings:
 
 x0
-                        | Axon X centroid position in pixels.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 y0
-                        | Axon Y centroid position in pixels.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 gratio
-                        Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
+                    Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter.
+
 axon_area
-                        | Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ .
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 axon_perimeter
-                        | Perimeter of the axon object in :math:`{\mu}`\ m.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 myelin_area
-                        Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
+                    Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
+
 axon_diameter
-                        | Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region).
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 myelin_thickness
-                        Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
+                    Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m.
+
 axonmyelin_area
-                        | Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ .
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 axonmyelin_perimeter
-                        | Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 solidity
-                        | Ratio of pixels in the axon region to pixels of the convex hull image.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 eccentricity
-                        | Eccentricity of the ellipse that has the same second-moments as the axon region.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
+                    Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+
 orientation
-                        | Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
-                        | Extracted from `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_
-
-
+                    Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -377,31 +377,31 @@ The resulting **'axon_morphometrics'** file will contain the following columns h
    * - Field
      - Description
    * - x0
-     - Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Axon X centroid position in pixels. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - y0
-     - Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Axon Y centroid position in pixels. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - gratio
      - Ratio between the axon equivalent diameter and the axon+myelin (fiber) equivalent diameter. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axon_area
-     - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Area of the axon region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - axon_perimeter
-     - Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Perimeter of the axon object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - myelin_area
      - Difference between axon+myelin (fiber) area and axon area in :math:`{\mu}`\ m\ :sup:`2`\ .
    * - axon_diameter
-     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Equivalent diameter of the axon in :math:`{\mu}`\ m (diameter of a circle with the same area as the region). Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - myelin_thickness
      - Half of the difference between the axon+myelin (fiber) diameter and the axon diameter in :math:`{\mu}`\ m. Note that the equivalent diameter is defined as the diameter of a circle with the same area as the region.
    * - axonmyelin_area
-     - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Area of the axon+myelin (fiber) region in :math:`{\mu}`\ m\ :sup:`2`\ . Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - axonmyelin_perimeter
-     - Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Perimeter of the axon+myelin (fiber) object in :math:`{\mu}`\ m. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - solidity
-     - Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Ratio of pixels in the axon region to pixels of the convex hull image. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - eccentricity
-     - Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Eccentricity of the ellipse that has the same second-moments as the axon region. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
    * - orientation
-     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <scikit-image https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
+     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region. Extracted with `skimage.measure.regionprops <https://scikit-image.org/docs/stable/api/skimage.measure.html#regionprops>`_.
 
 Jupyter notebooks
 -----------------


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR adds a description of the columns headings of the `axon_morphometrics` file produces by ADS.
`solidity`, `eccentricity` and `orientation` descriptions are taken directly from the descriptions of `skimage measure regionprops`.
