### PR TITLE
Add simulated image when `axon_shape` is circle

### DIFF
--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -43,6 +43,28 @@ class TestCore(object):
         pred_myelin_path = self.test_folder_path / ('image' + str(myelin_suffix))
         self.pred_myelin = imageio_imread(pred_myelin_path, as_gray=True)
 
+        # simulated image of axon myelin where axon shape is circle; `plane angle = 0`
+        self.path_sim_image_circle = (
+            self.testPath /
+            '__test_files__' /
+            '__test_simulated_axons__' /
+            'SimulatedAxons_shape_circle.png'
+        )
+
+        self.image_sim = SimulateAxons()
+
+        self.image_sim.generate_axon(axon_radius=50, center=[100, 100], gratio=0.9, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=45, center=[200, 200], gratio=0.8, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=40, center=[300, 300], gratio=0.7, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=35, center=[400, 400], gratio=0.6, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=30, center=[520, 520], gratio=0.5, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=23, center=[630, 630], gratio=0.4, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=18, center=[725, 725], gratio=0.3, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=12, center=[830, 830], gratio=0.2, plane_angle=0)
+        self.image_sim.generate_axon(axon_radius=6, center=[920, 920], gratio=0.1, plane_angle=0)
+
+        self.image_sim.save(self.path_sim_image_circle)
+
         self.tmpDir = self.fullPath / '__tmp__'
         if not self.tmpDir.exists():
             self.tmpDir.mkdir()
@@ -50,6 +72,9 @@ class TestCore(object):
     def teardown(self):
         if self.tmpDir.exists():
             shutil.rmtree(self.tmpDir)
+        
+        if self.path_sim_image_circle.exists():
+            self.path_sim_image_circle.unlink()
 
     # --------------get_pixelsize tests-------------- #
     @pytest.mark.unit
@@ -118,7 +143,7 @@ class TestCore(object):
             self.testPath /
             '__test_files__' /
             '__test_simulated_axons__' /
-            'SimulatedAxons.png'
+            'SimulatedAxons_shape_circle.png'
         )
 
         gratio_sim = np.array([
@@ -166,7 +191,7 @@ class TestCore(object):
             self.testPath /
             '__test_files__' /
             '__test_simulated_axons__' /
-            'SimulatedAxons.png'
+            'SimulatedAxons_shape_circle.png'
             )
 
         prediction = imageio_imread(path_pred, as_gray=True)
@@ -193,21 +218,8 @@ class TestCore(object):
             self.testPath /
             '__test_files__' /
             '__test_simulated_axons__' /
-            'SimulatedAxons_circle_test_perimeter.png'
+            'SimulatedAxons_shape_circle.png'
         )    
-        
-        image_sim = SimulateAxons()
-        image_sim.generate_axon(axon_radius=50, center=[100, 100], gratio=0.9, plane_angle=0)
-        image_sim.generate_axon(axon_radius=45, center=[200, 200], gratio=0.8, plane_angle=0)
-        image_sim.generate_axon(axon_radius=40, center=[300, 300], gratio=0.7, plane_angle=0)
-        image_sim.generate_axon(axon_radius=35, center=[400, 400], gratio=0.6, plane_angle=0)
-        image_sim.generate_axon(axon_radius=30, center=[520, 520], gratio=0.5, plane_angle=0)
-        image_sim.generate_axon(axon_radius=23, center=[640, 640], gratio=0.4, plane_angle=0)
-        image_sim.generate_axon(axon_radius=18, center=[725, 725], gratio=0.3, plane_angle=0)
-        image_sim.generate_axon(axon_radius=12, center=[830, 830], gratio=0.2, plane_angle=0)
-        image_sim.generate_axon(axon_radius=6, center=[920, 920], gratio=0.1, plane_angle=0)
-
-        image_sim.save(image_sim_path)
 
         axon_diam_sim = np.array([
                                     100,
@@ -248,21 +260,8 @@ class TestCore(object):
             self.testPath /
             '__test_files__' /
             '__test_simulated_axons__' /
-            'SimulatedAxons_circle_test_perimeter.png'
+            'SimulatedAxons_shape_circle.png'
         )    
-        
-        image_sim = SimulateAxons()
-        image_sim.generate_axon(axon_radius=50, center=[100, 100], gratio=0.9, plane_angle=0)
-        image_sim.generate_axon(axon_radius=45, center=[200, 200], gratio=0.8, plane_angle=0)
-        image_sim.generate_axon(axon_radius=40, center=[300, 300], gratio=0.7, plane_angle=0)
-        image_sim.generate_axon(axon_radius=35, center=[400, 400], gratio=0.6, plane_angle=0)
-        image_sim.generate_axon(axon_radius=30, center=[520, 520], gratio=0.5, plane_angle=0)
-        image_sim.generate_axon(axon_radius=23, center=[640, 640], gratio=0.4, plane_angle=0)
-        image_sim.generate_axon(axon_radius=18, center=[725, 725], gratio=0.3, plane_angle=0)
-        image_sim.generate_axon(axon_radius=12, center=[830, 830], gratio=0.2, plane_angle=0)
-        image_sim.generate_axon(axon_radius=6, center=[920, 920], gratio=0.1, plane_angle=0)
-
-        image_sim.save(image_sim_path)
 
         axon_diam_sim = np.array([
                                     100,


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks .It's ok to repeat some text from the related issue. -->

This quick PR aims to generate simulated image of axon myelin using [simulate_axons.py](https://github.com/neuropoly/axondeepseg/blob/master/AxonDeepSeg/visualization/simulate_axons.py) script rather than having the simulated image stored on the OSF under `__test_files__/__test_simulated_axons__/SimulatedAxons.png`

The simulated image and the actual `SimulatedAxons` are almost the same, that is, they both have the same **gratio**, same **plane_angle**, and same **axon_radius**. In this PR tests have been modified to generate simulated image. 

Before successfully merging this PR into `master` branch, the `__test_files__` directory also needs to be updated (without`SimulatedAxons.png`)  on OSF. Here is the updated  zip [__test_files__.zip](https://github.com/neuropoly/axondeepseg/files/6564360/__test_files__.zip).
