### PR TITLE
Update reqs for Mac M1 ARM. Remove dependencies: TF, Keras, and Albumentation. Remove FSLeyes (temporarily)

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: [ "3.7" ]
+        python-version: [ "3.9" ]
 
     # Main steps for the test to be reproduced across OS x Python
     steps:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: [ "3.9" ]
+        python-version: [ "3.8" ]
 
     # Main steps for the test to be reproduced across OS x Python
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - fsleyes=0.33.1
+  - fsleyes
   - h5py=2.10.0
   - numpy
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ads_venv
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.8
   - fsleyes
   - h5py=2.10.0
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - tabulate
   - pandas
   - matplotlib=3.3.4
-  - tensorflow=1.13.1
   - mpld3
   - tqdm
   - requests
@@ -23,10 +22,6 @@ dependencies:
   - prettytable
   - raven
   - jupyter
-  - Keras
-  - Keras-Applications
-  - Keras-Preprocessing
-  - albumentations=0.3.0
   - openpyxl
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,13 @@ name: ads_venv
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   - fsleyes=0.33.1
   - h5py=2.10.0
   - numpy
   - scipy
-  - scikit-learn=0.19.2
-  - scikit-image=0.14.2
+  - scikit-learn=0.24.2
+  - scikit-image=0.18.2
   - tabulate
   - pandas
   - matplotlib=3.3.4

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PostDevelopCommand(develop):
 
 setup(
     name='AxonDeepSeg',
-    python_requires='>=3.9, <3.10',
+    python_requires='>=3.8, <3.9',
     version=AxonDeepSeg.__version__,
     description='Python tool for automatic axon and myelin segmentation',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class PostDevelopCommand(develop):
 
 setup(
     name='AxonDeepSeg',
-    python_requires='>=3.7, <3.8',
+    python_requires='>=3.9, <3.10',
     version=AxonDeepSeg.__version__,
     description='Python tool for automatic axon and myelin segmentation',
     long_description=long_description,

--- a/test/testing/test_statistics_generation.py
+++ b/test/testing/test_statistics_generation.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-import tensorflow as tf
 import pandas as pd
 
 import pytest
@@ -58,7 +57,7 @@ class TestCore(object):
     @pytest.mark.integration
     def test_metrics_single_wrapper_runs_successfully_and_outfile_exists(self):
         # reset the tensorflow graph for new training
-        tf.reset_default_graph()
+        #tf.reset_default_graph()
 
         path_model_folder = self.modelPath
         path_images_folder = self.imagesPath
@@ -80,7 +79,7 @@ class TestCore(object):
     @pytest.mark.integration
     def test_metrics_classic_wrapper_runs_successfully_and_outfile_exists(self):
         # reset the tensorflow graph for new training
-        tf.reset_default_graph()
+        #tf.reset_default_graph()
 
         path_model_folder = self.modelPath
         path_images_folder = self.imagesPath


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
As we're moving to IVADOMED, I think we can scrap the following requirements: Tensorflow, Keras, and Albumentations. This should also conveniently make AxonDeepSeg compatible with Macs using the ARM M1 processor, as long as there's no issues on the IVADOMED side (?).

I've also updated the requirements for Mac M1 ARM compatibility (MiniForge isn't compatible with Python 3.7). I've increased it to Python 3.9, but am not sure if this will break FSLeyes compatibility. If it does, maybe we should continue anyways (or downgrade to 3.8) and see if we can resolve it on the FSLeyes side.

## Linked issues
#523 