### PR TITLE
Fix morphometrics error with ellipse axon shape

### DIFF
--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20210625.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20210906.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20210906.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20210906b.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -156,15 +156,19 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                 # Perimeter of axonmyelin instance (outer perimeter of myelin) in micrometers
                 axonmyelin_perimeter = prop_axonmyelin.perimeter * pixelsize
 
-                stats['myelin_thickness'] = myelin_thickness
-                stats['myelin_area'] = myelin_area
-                stats['axonmyelin_area'] = axonmyelin_area
-                stats['axonmyelin_perimeter'] = axonmyelin_perimeter
                 try:
                     stats['gratio'] = (axon_diam / 2) / (axon_diam / 2 + myelin_thickness)
+                    stats['myelin_thickness'] = myelin_thickness
+                    stats['myelin_area'] = myelin_area
+                    stats['axonmyelin_area'] = axonmyelin_area
+                    stats['axonmyelin_perimeter'] = axonmyelin_perimeter
                 except ZeroDivisionError:
-                    print(f"ZeroDivisionError: skipping element {idx}.")
+                    print(f"ZeroDivisionError caught on invalid object #{idx}.")
                     stats['gratio'] = float('NaN')
+                    stats['myelin_thickness'] = float('NaN')
+                    stats['myelin_area'] = float('NaN')
+                    stats['axonmyelin_area'] = float('NaN')
+                    stats['axonmyelin_perimeter'] = float('NaN')
 
             else:
                 print(

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -160,7 +160,11 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                 stats['myelin_area'] = myelin_area
                 stats['axonmyelin_area'] = axonmyelin_area
                 stats['axonmyelin_perimeter'] = axonmyelin_perimeter
-                stats['gratio'] = (axon_diam / 2) / (axon_diam / 2 + myelin_thickness)
+                try:
+                    stats['gratio'] = (axon_diam / 2) / (axon_diam / 2 + myelin_thickness)
+                except ZeroDivisionError:
+                    print(f"ZeroDivisionError: skipping element {idx}.")
+                    stats['gratio'] = float('NaN')
 
             else:
                 print(

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -216,10 +216,10 @@ def main(argv=None):
             try:
                 # Export to excel
                 if morph_filename.endswith('.xlsx'):
-                    pd.DataFrame(x).to_excel(current_path_target.parent / morph_filename)
+                    pd.DataFrame(x).to_excel(current_path_target.parent / morph_filename, na_rep='NaN')
                 # Export to csv    
                 else: 
-                    pd.DataFrame(x).to_csv(current_path_target.parent / morph_filename)
+                    pd.DataFrame(x).to_csv(current_path_target.parent / morph_filename, na_rep='NaN')
 
                 # Generate the index image
                 indexes_outfile = current_path_target.parent /(str(current_path_target.with_suffix("")) +

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -43,6 +43,12 @@ class TestCore(object):
         pred_myelin_path = self.test_folder_path / ('image' + str(myelin_suffix))
         self.pred_myelin = imageio_imread(pred_myelin_path, as_gray=True)
 
+        # Image to test NaN output
+        bad_pred_axon_path = self.test_folder_path / ('invalid_gratio' + str(axon_suffix))
+        self.bad_pred_axon = imageio_imread(bad_pred_axon_path, as_gray=True)
+        bad_pred_myelin_path = self.test_folder_path / ('invalid_gratio' + str(myelin_suffix))
+        self.bad_pred_myelin = imageio_imread(bad_pred_myelin_path, as_gray=True)
+
         # simulated image of axon myelin where axon shape is circle; `plane angle = 0`
         self.path_sim_image_circle = (
             self.testPath /
@@ -174,6 +180,16 @@ class TestCore(object):
         print("The values are ", stats_array[1]['gratio'], stats_array[1]['axon_diam'], stats_array[1]['myelin_thickness'])    
     
         assert stats_array[1]['gratio'] == pytest.approx(0.78, rel=0.01)
+
+    @pytest.mark.unit
+    def test_get_axon_morphometrics_with_invalid_gratio_with_axon_as_ellipse(self):
+        stats_array = get_axon_morphometrics(
+            self.bad_pred_axon,
+            str(self.test_folder_path),
+            im_myelin=self.bad_pred_myelin,
+            axon_shape=self.axon_shape
+            )
+        assert np.isnan(stats_array[0]['gratio'])
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons(self):


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR aims to handle the ZeroDivisionError that sometimes happen when computing morphometrics with the ellipse axon shape. The adopted solution is to output a NaN value in the output CSV file when that happens. What is left to do:
- [x] invalidate other metrics when error is caught
- [x] add test image to test this behavior in the future

## Linked issues
Resolves #557 