### PR TITLE
Update figure link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Based on a convolutional neural network architecture. Pixels are classified as e
 
 For more information, see the [documentation website](http://axondeepseg.readthedocs.io/).
 
-![alt tag](https://github.com/neuropoly/axondeepseg/blob/master/docs/source/_static/fig0.png)
+![alt tag](https://raw.githubusercontent.com/axondeepseg/doc-figures/main/index/fig0.png)
 
 
 


### PR DESCRIPTION
Just noticed the README figure was missing:

<img width="950" alt="Screen Shot 2021-10-26 at 11 08 24 PM" src="https://user-images.githubusercontent.com/1421029/138987809-010b7ad6-4f6e-49d9-a99c-532f0c8d1da4.png">

This PR brings it back:

<img width="950" alt="Screen Shot 2021-10-26 at 11 08 16 PM" src="https://user-images.githubusercontent.com/1421029/138987843-11d44ceb-3a93-46ca-97e7-0988aec37e8d.png">

