### PR TITLE
Increase conda timeout to 1 hour

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -99,6 +99,7 @@ jobs:
           COVERALLS_PARALLEL: true
         run: |
           pip install coveralls
+          conda config --set remote_read_timeout_secs 6000
           pytest . -v --cov AxonDeepSeg/ --cov-report term-missing
           coveralls --service=github
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


## Description
Increased the conda timeout to 1 hour to help the scheduled tests from failing due to timeouts
