### PR TITLE
Fix NaNs not appearing when generating morphometrics with the GUI

### DIFF
--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -725,7 +725,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 pathname = pathname + ".xlsx"
             try:
                 # Export to excel
-                pd.DataFrame(x).to_excel(pathname)
+                pd.DataFrame(x).to_excel(pathname, na_rep='NaN')
 
             except IOError:
                 wx.LogError("Cannot save current data in file '%s'." % pathname)


### PR DESCRIPTION
Quick fix for the issue mentionned in #587 where NaNs wouldn't appear in the morphometrics file if it was generated in the GUI.