### PR TITLE
Patch RTD setup to deprication

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,14 +4,12 @@
 
 # Required
 version: 2
+conda:
+  environment: docs/environment.yml
 build:
   os: "ubuntu-22.04"
   tools:
       python: "miniconda3-4.7"
-
-python:
-  install:
-    - requirements: docs/requirements.txt
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
RTD build today failed, https://readthedocs.org/projects/axondeepseg/builds/22281707/

Following message was given:

>Build failed
>Your builds will stop working soon!
>"build.image" config key is deprecated and it will be removed soon. [Read our blog post to know how to migrate to new key "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.

And this error:

>The configuration key "build.os" is required to build your documentation. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

The changes in this PR fixed our broken build and it passes again: https://readthedocs.org/projects/axondeepseg/builds/22282186/