### PR TITLE
[Plugin] Reset instance seg and database state when mask is loaded or generated

### DIFF
--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -560,6 +560,9 @@ class ADSplugin(QWidget):
         )
         myelin_mask_name = image_name_no_extension + myelin_suffix.stem
 
+        # Reset cached state when new masks are loaded
+        self._reset_cached_state()
+
         axon_data = ads_utils.imread(axon_mask_path).astype(bool)
         self.viewer.add_labels(
             axon_data,
@@ -613,6 +616,10 @@ class ADSplugin(QWidget):
             "The mask will be associated with " + microscopy_image_layer.name
         ):
             return
+
+        # Reset cached state when new masks are loaded
+        self._reset_cached_state()
+
         img_png2D = ads_utils.imread(mask_file_path)
         # Extract the Axon mask
         axon_data = img_png2D > 200
@@ -1263,6 +1270,20 @@ class ADSplugin(QWidget):
             "Zaimi et al (2018): https://doi.org/10.1038/s41598-018-22181-4. \n"
             "Copyright (c) 2018 NeuroPoly (Polytechnique Montreal)"
         )
+
+    def _reset_cached_state(self):
+        """Reset all cached state variables related to the current image/mask.
+
+        This should be called when new masks are loaded to prevent state from
+        previous images from affecting operations on the new image.
+
+        Returns:
+            None
+        """
+        self.im_instance_seg = None
+        self.stats_dataframe = None
+        self.index_image_array = None
+        self.im_axonmyelin_label = None
 
 class ApplyModelThread(QtCore.QThread):
     """QThread class used to segment an image by applying a model in a separate thread.


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

A user (@soomin2189) raised in #941 that the axon removal toggle wasn't behaving as expected when a second image was loaded after using the feature with a first image. I found that it was due to some variables not being reset when the new mask was loaded or segmented. With the fix in this PR, the bug appears to have been fixed for me.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #941 