### PR TITLE
Fix bug when RGB image is loaded to napari

### DIFF
--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -551,6 +551,8 @@ class ADSplugin(QWidget):
         potential_target_name = image_name_no_extension + "_grayscale.png"
         if (image_directory / potential_target_name).exists():
             image_name_no_extension += '_grayscale'
+            # Update the napari layer name to match the converted file
+            selected_layer.name = image_name_no_extension
         axon_mask_path = image_directory / (
             image_name_no_extension + str(axon_suffix)
         )


### PR DESCRIPTION
Resolves #951

You can test it before/after by using a screenshot of an image, or just downloading this one,

<img width="431" height="350" alt="Screenshot 2026-01-23 at 2 40 09 PM" src="https://github.com/user-attachments/assets/a2084129-be96-4050-a344-7255a62d8aea" />

Before fix: error thrown when computing morphometrics, image file has the original filename listed in napari

After fix: no error thrown, image file has the filename with a suffix "_grayscale.png" listed in napari