### PR TITLE
Diameter approximation overlay

### DIFF
--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -248,7 +248,7 @@ class ADSplugin(QWidget):
         qa_report_button.setToolTip("Generate quality assurance report for the segmentation.\nRequires morphometrics to be computed.")
         self.qa_report_button = qa_report_button
 
-        settings_menu_button = QPushButton("Settingss")
+        settings_menu_button = QPushButton("Settings")
         settings_menu_button.clicked.connect(self._on_settings_menu_clicked)
 
         self.setLayout(QVBoxLayout())
@@ -1075,6 +1075,21 @@ class ADSplugin(QWidget):
         )
         
         self.im_axonmyelin_label = im_axonmyelin_label
+
+        if self.settings.axon_shape == 'ellipse':
+            overlay_array = postprocessing.generate_diameter_overlay(
+                stats_dataframe=stats_dataframe,
+                image_shape=axon_data.shape,
+                pixel_size=pixel_size,
+                axon_shape=self.settings.axon_shape,
+            )
+            self.viewer.add_image(
+                data=np.array(overlay_array),
+                rgb=False,
+                colormap="yellow",
+                blending="additive",
+                name="diameter overlay",
+            )
 
         return True
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -202,6 +202,8 @@ def get_axon_morphometrics(
         if im_myelin is not None:
             # Declare the statistics to add for the myelin and add them to the stats dictionary
             myelin_stats = {
+                'fiber_orientation': np.nan,
+                'fiber_eccentricity': np.nan,
                 'gratio': np.nan,
                 'myelin_thickness': np.nan,
                 'myelin_area': np.nan,
@@ -216,6 +218,9 @@ def get_axon_morphometrics(
             if label_axonmyelin:
                 idx = axonmyelin_labels_list.index(label_axonmyelin)
                 prop_axonmyelin = axonmyelin_objects[idx]
+
+                stats['fiber_orientation'] = prop_axonmyelin.orientation
+                stats['fiber_eccentricity'] = prop_axonmyelin.eccentricity
 
                 _res1 = evaluate_myelin_thickness_in_px(prop_axon, prop_axonmyelin, axon_shape)
                 myelin_thickness = pixelsize * _res1

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -167,8 +167,8 @@ def main(argv=None):
         '-d', '--diameter-overlay',
         required=False,
         action='store_true',
-        help='Generate a diameter overlay image with concentric circles for each axon. \n'
-            +'Only works for myelinated axons with axon_shape="circle". \n'
+        help='Generate a diameter overlay image with concentric shapes for each axon. \n'
+            +'Works for myelinated axons with axon_shape="circle" or axon_shape="ellipse". \n'
             +'Skipped for unmyelinated and nerve modes.'
     )
 
@@ -348,7 +348,7 @@ def main(argv=None):
                     instance_map = instance_map.astype(np.uint16)
                     ads.imwrite(outfile_basename + str(instance_suffix), instance_map, use_16bit=True)
 
-                # Generate diameter overlay if requested (only for myelinated mode with circle axon shape)
+                # Generate diameter overlay if requested (myelinated mode only, circle or ellipse axon shape)
                 if diameter_overlay_flag and morphometrics_mode == 'myelinated':
                     overlay_array = postprocessing.generate_diameter_overlay(
                         stats_dataframe, 

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -14,6 +14,8 @@ import numpy as np
 import pandas as pd
 
 # AxonDeepSeg imports
+import AxonDeepSeg
+from AxonDeepSeg.ads_utils import convert_path
 from AxonDeepSeg.morphometrics.compute_morphometrics import (
     get_axon_morphometrics,
     save_axon_morphometrics,
@@ -26,17 +28,16 @@ from AxonDeepSeg.morphometrics.compute_morphometrics import (
     compute_axon_density
 )
 import AxonDeepSeg.ads_utils as ads
+from AxonDeepSeg import postprocessing, params
 from AxonDeepSeg.params import (
     axon_suffix, myelin_suffix, axonmyelin_suffix,
     index_suffix, axonmyelin_index_suffix,
     morph_suffix, unmyelinated_morph_suffix, 
     instance_im_suffix, instance_suffix, 
     unmyelinated_suffix, unmyelinated_index_suffix,
-    nerve_suffix, nerve_morph_suffix, nerve_index_suffix
+    nerve_suffix, nerve_morph_suffix, nerve_index_suffix,
+    diameter_overlay_suffix
 )
-from AxonDeepSeg.ads_utils import convert_path
-from AxonDeepSeg import postprocessing, params
-import AxonDeepSeg
 
 
 def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circle"):
@@ -162,6 +163,14 @@ def main(argv=None):
         help='Toggles morphometrics for nerve sections. This will only process masks with \n'
             +f'the "{nerve_suffix}" suffix, and compute axon density inside the nerve area.'
     )
+    ap.add_argument(
+        '-d', '--diameter-overlay',
+        required=False,
+        action='store_true',
+        help='Generate a diameter overlay image with concentric circles for each axon. \n'
+            +'Only works for myelinated axons with axon_shape="circle". \n'
+            +'Skipped for unmyelinated and nerve modes.'
+    )
 
     # Processing the arguments
     args = vars(ap.parse_args(argv))
@@ -171,6 +180,7 @@ def main(argv=None):
     colorization_flag = args["colorize"]
     unmyelinated_mode = args["unmyelinated"]
     nerve_mode = args["nerve"]
+    diameter_overlay_flag = args["diameter_overlay"]
     if nerve_mode:
         morphometrics_mode = 'nerve'
         target_suffix = nerve_suffix
@@ -337,6 +347,18 @@ def main(argv=None):
                     ads.imwrite(outfile_basename + str(instance_im_suffix), instance_seg_image)
                     instance_map = instance_map.astype(np.uint16)
                     ads.imwrite(outfile_basename + str(instance_suffix), instance_map, use_16bit=True)
+
+                # Generate diameter overlay if requested (only for myelinated mode with circle axon shape)
+                if diameter_overlay_flag and morphometrics_mode == 'myelinated' and axon_shape == "circle":
+                    overlay_array = postprocessing.generate_diameter_overlay(
+                        stats_dataframe, 
+                        pred_axon.shape, 
+                        psm, 
+                        axon_shape=axon_shape
+                    )
+                    if overlay_array is not None:
+                        overlay_fname = outfile_basename + str(diameter_overlay_suffix)
+                        postprocessing.save_diameter_overlay(overlay_array, overlay_fname)
 
                 logger.info("Morphometrics file: {} has been saved in the {} directory",
                     morph_filename,

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -349,12 +349,11 @@ def main(argv=None):
                     ads.imwrite(outfile_basename + str(instance_suffix), instance_map, use_16bit=True)
 
                 # Generate diameter overlay if requested (only for myelinated mode with circle axon shape)
-                if diameter_overlay_flag and morphometrics_mode == 'myelinated' and axon_shape == "circle":
+                if diameter_overlay_flag and morphometrics_mode == 'myelinated':
                     overlay_array = postprocessing.generate_diameter_overlay(
                         stats_dataframe, 
                         pred_axon.shape, 
-                        psm, 
-                        axon_shape=axon_shape
+                        psm
                     )
                     if overlay_array is not None:
                         overlay_fname = outfile_basename + str(diameter_overlay_suffix)

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -353,7 +353,8 @@ def main(argv=None):
                     overlay_array = postprocessing.generate_diameter_overlay(
                         stats_dataframe, 
                         pred_axon.shape, 
-                        psm
+                        psm,
+                        axon_shape=axon_shape
                     )
                     if overlay_array is not None:
                         overlay_fname = outfile_basename + str(diameter_overlay_suffix)

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -12,6 +12,7 @@ unmyelinated_index_suffix = Path('_uaxon_index.png')    # Colored unmyelinated a
 nnunet_suffix=Path('_seg-nnunet.png')                   # nnunet raw segmentation suffix
 nerve_suffix=Path('_seg-nerve.png')                     # nerve segmentation suffix
 nerve_index_suffix=Path('_nerve_index.png')             # Colored nerve segmentation + the index image
+diameter_overlay_suffix = Path('_diameter_overlay.png') # Diameter overlay with concentric circles
 
 side_effect_suffixes = tuple(
     [

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -91,4 +91,8 @@ column_names_ordered = [
     Morphometrics_Column_Name('myelin_thickness','myelin_thickness (um)'),
     Morphometrics_Column_Name('axonmyelin_area','axonmyelin_area (um^2)'),
     Morphometrics_Column_Name('axonmyelin_perimeter','axonmyelin_perimeter (um)'),
+    Morphometrics_Column_Name('eccentricity'),
+    Morphometrics_Column_Name('orientation'),
+    Morphometrics_Column_Name('fiber_eccentricity'),
+    Morphometrics_Column_Name('fiber_orientation'),
 ]

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -14,16 +14,6 @@ nerve_suffix=Path('_seg-nerve.png')                     # nerve segmentation suf
 nerve_index_suffix=Path('_nerve_index.png')             # Colored nerve segmentation + the index image
 diameter_overlay_suffix = Path('_diameter_overlay.png') # Diameter overlay with concentric circles
 
-side_effect_suffixes = tuple(
-    [
-        str(s) for s in [
-            axonmyelin_suffix, axon_suffix, myelin_suffix, index_suffix, 
-            axonmyelin_index_suffix, unmyelinated_suffix, unmyelinated_index_suffix,
-            nnunet_suffix
-        ]
-    ]
-)
-
 # morphometrics file suffix name
 morph_suffix = Path('axon_morphometrics.xlsx')
 morph_agg_suffix = Path('subject_morphometrics.xlsx')
@@ -31,6 +21,14 @@ unmyelinated_morph_suffix = Path('uaxon_morphometrics.xlsx')
 nerve_morph_suffix = Path('nerve_morphometrics.json')
 instance_im_suffix = Path('_colorized.png')             # Colored instance map of the segmentation
 instance_suffix = Path('_instance-map.png')             # Raw instance map of the segmentation
+
+# All pipeline-generated file suffixes — used by segment_folder() to skip outputs when
+# batch-processing a folder. Built automatically from all module-level Path variables
+# whose names end in '_suffix', so new suffixes are included without manual updates.
+generated_file_suffixes = tuple(
+    str(v) for k, v in list(globals().items())
+    if k.endswith('_suffix') and isinstance(v, Path)
+)
 
 # aggregate morphometrics file suffix name
 agg_dir = Path('morphometrics_agg')

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -210,10 +210,42 @@ def generate_rotated_ellipse_points(center_x, center_y, semi_major, semi_minor, 
 def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, line_width=2, axon_shape='circle'):
     """
     Generate an overlay image with concentric circles or ellipses for each axon.
-    For circles: each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
-    For ellipses: each axon has two ellipses with correct major/minor axes and orientation based on eccentricity and orientation columns.
-    
-    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness, eccentricity, orientation, fiber_eccentricity, fiber_orientation
+
+    For circles: each axon has two circles: one with axon_diameter and one with
+    axon_diameter + 2*myelin_thickness.
+
+    For ellipses: the ellipses are NOT fits to the actual mask perimeters. They are
+    reconstructed from second-moment (inertia-tensor) statistics computed by
+    skimage.measure.regionprops (see
+    https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.regionprops).
+
+    For the inner (axon) ellipse:
+      1. regionprops computes minor_axis_length, eccentricity (e), and orientation for the axon
+         mask. These are stored as axon_diam (= minor_axis_length) and eccentricity in the
+         morphometrics dataframe.
+      2. The semi-minor axis b = axon_diam / 2.
+      3. The semi-major axis a is derived via a = b / sqrt(1 - e^2), which follows from
+         skimage's definition e = c/a (focal distance over major axis length) combined with the
+         ellipse identity c^2 = a^2 - b^2.
+      4. The inner ellipse is drawn using b, a, and orientation.
+
+    For the outer (fiber) ellipse:
+      1. regionprops separately computes minor_axis_length, eccentricity, and orientation for
+         the full axonmyelin mask. fiber_eccentricity and fiber_orientation are stored in the
+         morphometrics dataframe. myelin_thickness is derived as
+         (axonmyelin.minor_axis_length - axon.minor_axis_length) / 2.
+      2. NOTE: in ellipse mode, myelin_thickness represents the thickness along the minor axis
+         only — NOT a mean or uniform perimeter thickness. A true uniform myelin sheath on an
+         elliptical axon would not produce an elliptical outer boundary, so the two ellipses are
+         modeled independently from their respective regionprops. For circles, the ring is
+         uniform and this distinction does not apply.
+      3. The outer semi-minor axis = b + myelin_thickness (= axonmyelin.minor_axis_length / 2).
+      4. The outer semi-major axis is derived from fiber_eccentricity using the same formula,
+         and the ellipse is drawn using fiber_orientation.
+
+    :param stats_dataframe: DataFrame containing axon morphometrics with columns:
+        x0, y0, axon_diam, myelin_thickness, eccentricity, orientation,
+        fiber_eccentricity, fiber_orientation
     :param image_shape: Tuple (height, width) of the image
     :param pixel_size: Pixel size in micrometers (used to convert diameters back to pixels)
     :param line_width: Width of the outlines in pixels (default: 2)

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -4,9 +4,13 @@ Tools for the FSLeyes plugin and other functions for manipulating masks.
 from skimage import measure, morphology, segmentation
 from PIL import Image, ImageDraw, ImageOps, ImageFont
 import numpy as np
-from AxonDeepSeg import params
-import AxonDeepSeg.morphometrics.compute_morphometrics as compute_morphs
+import pandas as pd
 from matplotlib import font_manager
+from loguru import logger
+
+from AxonDeepSeg import params
+from AxonDeepSeg.ads_utils import convert_path, imwrite
+import AxonDeepSeg.morphometrics.compute_morphometrics as compute_morphs
 
 def get_centroids(mask):
     """
@@ -169,3 +173,90 @@ def remove_axons_at_coordinates(im_axon, im_myelin, x0s, y0s):
     axon_array = (im_axon & new_axonmyelin_array).astype(np.uint8)
     myelin_array = (im_myelin & new_axonmyelin_array).astype(np.uint8)
     return axon_array, myelin_array
+
+def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, axon_shape="circle"):
+    """
+    Generate an overlay image with concentric circles for each axon.
+    Each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
+    
+    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness
+    :param image_shape: Tuple (height, width) of the image
+    :param pixel_size: Pixel size in micrometers (used to convert diameters back to pixels)
+    :param axon_shape: str: only works for "circle" mode (will skip for ellipse)
+    :return: numpy array with white circle outlines on black background
+    """    
+
+    if axon_shape != "circle":
+        logger.debug("Diameter overlay only supported for axon_shape='circle'. Skipping.")
+        return None
+    
+    overlay = Image.new('L', (image_shape[1], image_shape[0]), color=0)
+    draw = ImageDraw.Draw(overlay)
+    line_width = 2
+    
+    compute_bbox = lambda center_x, center_y, radius: (
+        center_x - radius,
+        center_y - radius,
+        center_x + radius,
+        center_y + radius
+    )
+    
+    # Iterate through each axon in the stats_dataframe
+    for idx, row in stats_dataframe.iterrows():
+        x0 = row['x0']
+        y0 = row['y0']
+        
+        if pd.isna(x0) or pd.isna(y0) or pd.isna(row['axon_diam']):
+            logger.debug(f"Skipping axon {idx}: missing centroid or axon_diam")
+            continue
+        
+        # Convert from micrometers to pixels
+        axon_diam_px = row['axon_diam'] / pixel_size
+        axon_radius_px = axon_diam_px / 2
+        
+        # Draw inner circle (axon diameter)
+        x_min, y_min, x_max, y_max = compute_bbox(x0, y0, axon_radius_px)
+        
+        draw.ellipse(
+            [(x_min, y_min), (x_max, y_max)],
+            outline=255,
+            width=line_width
+        )
+        
+        # Draw outer circle (axon + myelin) if myelin_thickness is available
+        if not pd.isna(row['myelin_thickness']):
+            myelin_thickness_px = row['myelin_thickness'] / pixel_size
+            outer_radius_px = axon_radius_px + myelin_thickness_px
+            
+            x_min_outer, y_min_outer, x_max_outer, y_max_outer = compute_bbox(x0, y0, outer_radius_px)
+            
+            draw.ellipse(
+                [(x_min_outer, y_min_outer), (x_max_outer, y_max_outer)],
+                outline=255,
+                width=line_width
+            )
+    
+    # Convert PIL image to numpy array
+    overlay_array = np.array(overlay, dtype=np.uint8)
+    
+    return overlay_array
+
+def save_diameter_overlay(overlay_array, output_path):
+    """
+    Save the diameter overlay array as an image file.
+    
+    :param overlay_array: numpy array with the diameter overlay
+    :param output_path: Path where the overlay image will be saved
+    :return: None
+    """    
+    if overlay_array is None:
+        logger.debug("Diameter overlay is None, skipping save.")
+        return
+    
+    output_path = convert_path(output_path)
+    
+    try:
+        imwrite(str(output_path), overlay_array)
+        logger.info(f"Diameter overlay saved to {output_path}")
+    except Exception as e:
+        logger.warning(f"Could not save diameter overlay to {output_path}: {e}")

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -174,21 +174,18 @@ def remove_axons_at_coordinates(im_axon, im_myelin, x0s, y0s):
     myelin_array = (im_myelin & new_axonmyelin_array).astype(np.uint8)
     return axon_array, myelin_array
 
-def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, axon_shape="circle"):
+def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size):
     """
     Generate an overlay image with concentric circles for each axon.
     Each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
     
+    This function is agnostic to axon shape and works for both circle and ellipse modes.
+    
     :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness
     :param image_shape: Tuple (height, width) of the image
     :param pixel_size: Pixel size in micrometers (used to convert diameters back to pixels)
-    :param axon_shape: str: only works for "circle" mode (will skip for ellipse)
     :return: numpy array with white circle outlines on black background
     """    
-
-    if axon_shape != "circle":
-        logger.debug("Diameter overlay only supported for axon_shape='circle'. Skipping.")
-        return None
     
     overlay = Image.new('L', (image_shape[1], image_shape[0]), color=0)
     draw = ImageDraw.Draw(overlay)

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -174,24 +174,57 @@ def remove_axons_at_coordinates(im_axon, im_myelin, x0s, y0s):
     myelin_array = (im_myelin & new_axonmyelin_array).astype(np.uint8)
     return axon_array, myelin_array
 
-def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size):
+def generate_rotated_ellipse_points(center_x, center_y, semi_major, semi_minor, orientation, num_points=64):
     """
-    Generate an overlay image with concentric circles for each axon.
-    Each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
+    Generate points along a rotated ellipse perimeter.
     
-    This function is agnostic to axon shape and works for both circle and ellipse modes.
+    :param center_x: X coordinate of ellipse center
+    :param center_y: Y coordinate of ellipse center
+    :param semi_major: Semi-major axis length
+    :param semi_minor: Semi-minor axis length
+    :param orientation: Rotation angle in radians (0th axis to major axis)
+    :param num_points: Number of points to sample along the ellipse
+    :return: List of (x, y) tuples representing the ellipse perimeter
+    """
+    points = []
+    orientation = -orientation  # Negate to match image coordinate system
+    for i in range(num_points):
+        t = 2 * np.pi * i / num_points
+        # Unrotated ellipse points
+        x_ellipse = semi_minor * np.cos(t)
+        y_ellipse = semi_major * np.sin(t)
+        
+        # Rotate by orientation angle
+        cos_angle = np.cos(orientation)
+        sin_angle = np.sin(orientation)
+        x_rotated = x_ellipse * cos_angle - y_ellipse * sin_angle
+        y_rotated = x_ellipse * sin_angle + y_ellipse * cos_angle
+        
+        # Translate to center
+        x_final = center_x + x_rotated
+        y_final = center_y + y_rotated
+        points.append((x_final, y_final))
     
-    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness
+    return points
+
+def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, line_width=2, axon_shape='circle'):
+    """
+    Generate an overlay image with concentric circles or ellipses for each axon.
+    For circles: each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
+    For ellipses: each axon has two ellipses with correct major/minor axes and orientation based on eccentricity and orientation columns.
+    
+    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness, eccentricity, orientation
     :param image_shape: Tuple (height, width) of the image
     :param pixel_size: Pixel size in micrometers (used to convert diameters back to pixels)
-    :return: numpy array with white circle outlines on black background
+    :param line_width: Width of the outlines in pixels (default: 2)
+    :param axon_shape: Shape of the axons ('circle' or 'ellipse').
+    :return: numpy array with white circle/ellipse outlines on black background
     """    
     
     overlay = Image.new('L', (image_shape[1], image_shape[0]), color=0)
     draw = ImageDraw.Draw(overlay)
-    line_width = 2
     
-    compute_bbox = lambda center_x, center_y, radius: (
+    compute_bbox_circle = lambda center_x, center_y, radius: (
         center_x - radius,
         center_y - radius,
         center_x + radius,
@@ -211,27 +244,60 @@ def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size):
         axon_diam_px = row['axon_diam'] / pixel_size
         axon_radius_px = axon_diam_px / 2
         
-        # Draw inner circle (axon diameter)
-        x_min, y_min, x_max, y_max = compute_bbox(x0, y0, axon_radius_px)
-        
-        draw.ellipse(
-            [(x_min, y_min), (x_max, y_max)],
-            outline=255,
-            width=line_width
-        )
-        
-        # Draw outer circle (axon + myelin) if myelin_thickness is available
-        if not pd.isna(row['myelin_thickness']):
-            myelin_thickness_px = row['myelin_thickness'] / pixel_size
-            outer_radius_px = axon_radius_px + myelin_thickness_px
+        if axon_shape == 'ellipse':
+            # For ellipse mode, axon_diam is the minor axis
+            # Calculate semi-major axis from eccentricity using: a = b / sqrt(1 - e^2)
+            if pd.isna(row['eccentricity']):
+                logger.debug(f"Skipping axon {idx}: missing eccentricity for ellipse mode")
+                continue
             
-            x_min_outer, y_min_outer, x_max_outer, y_max_outer = compute_bbox(x0, y0, outer_radius_px)
+            e = row['eccentricity']
+            # Avoid division by zero and invalid eccentricity values
+            if e >= 1.0 or e < 0.0:
+                logger.debug(f"Skipping axon {idx}: invalid eccentricity value {e}")
+                continue
+            
+            # Get orientation if available, default to 0
+            orientation = row['orientation'] if not pd.isna(row['orientation']) else 0.0
+            
+            semi_minor_axis_px = axon_radius_px  # This is b
+            # Calculate semi-major axis: a = b / sqrt(1 - e**2)
+            semi_major_axis_px = semi_minor_axis_px / np.sqrt(1 - e**2)
+            
+            # Generate and draw inner ellipse (axon)
+            inner_points = generate_rotated_ellipse_points(x0, y0, semi_major_axis_px, semi_minor_axis_px, orientation)
+            draw.polygon(inner_points, outline=255, width=line_width)
+            
+            # Draw outer ellipse (axon + myelin) if myelin_thickness is available
+            if not pd.isna(row['myelin_thickness']):
+                myelin_thickness_px = row['myelin_thickness'] / pixel_size
+                outer_semi_major_px = semi_major_axis_px + myelin_thickness_px
+                outer_semi_minor_px = semi_minor_axis_px + myelin_thickness_px
+                
+                outer_points = generate_rotated_ellipse_points(x0, y0, outer_semi_major_px, outer_semi_minor_px, orientation)
+                draw.polygon(outer_points, outline=255, width=line_width)
+        elif axon_shape == 'circle':
+            # Draw inner circle (axon diameter)
+            x_min, y_min, x_max, y_max = compute_bbox_circle(x0, y0, axon_radius_px)
             
             draw.ellipse(
-                [(x_min_outer, y_min_outer), (x_max_outer, y_max_outer)],
+                [(x_min, y_min), (x_max, y_max)],
                 outline=255,
                 width=line_width
             )
+            
+            # Draw outer circle (axon + myelin) if myelin_thickness is available
+            if not pd.isna(row['myelin_thickness']):
+                myelin_thickness_px = row['myelin_thickness'] / pixel_size
+                outer_radius_px = axon_radius_px + myelin_thickness_px
+                
+                x_min_outer, y_min_outer, x_max_outer, y_max_outer = compute_bbox_circle(x0, y0, outer_radius_px)
+                
+                draw.ellipse(
+                    [(x_min_outer, y_min_outer), (x_max_outer, y_max_outer)],
+                    outline=255,
+                    width=line_width
+                )
     
     # Convert PIL image to numpy array
     overlay_array = np.array(overlay, dtype=np.uint8)

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -213,7 +213,7 @@ def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, line_wid
     For circles: each axon has two circles: one with axon_diameter and one with axon_diameter + 2*myelin_thickness.
     For ellipses: each axon has two ellipses with correct major/minor axes and orientation based on eccentricity and orientation columns.
     
-    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness, eccentricity, orientation
+    :param stats_dataframe: DataFrame containing axon morphometrics with columns: x0, y0, axon_diam, myelin_thickness, eccentricity, orientation, fiber_eccentricity, fiber_orientation
     :param image_shape: Tuple (height, width) of the image
     :param pixel_size: Pixel size in micrometers (used to convert diameters back to pixels)
     :param line_width: Width of the outlines in pixels (default: 2)
@@ -271,10 +271,24 @@ def generate_diameter_overlay(stats_dataframe, image_shape, pixel_size, line_wid
             # Draw outer ellipse (axon + myelin) if myelin_thickness is available
             if not pd.isna(row['myelin_thickness']):
                 myelin_thickness_px = row['myelin_thickness'] / pixel_size
-                outer_semi_major_px = semi_major_axis_px + myelin_thickness_px
                 outer_semi_minor_px = semi_minor_axis_px + myelin_thickness_px
                 
-                outer_points = generate_rotated_ellipse_points(x0, y0, outer_semi_major_px, outer_semi_minor_px, orientation)
+                # Use fiber_eccentricity and fiber_orientation if available
+                if not pd.isna(row['fiber_eccentricity']) and not pd.isna(row['fiber_orientation']):
+                    fiber_e = row['fiber_eccentricity']
+                    # Avoid division by zero and invalid eccentricity values
+                    if 0.0 <= fiber_e < 1.0:
+                        # Calculate semi-major axis from fiber eccentricity and outer minor axis
+                        outer_semi_major_px = outer_semi_minor_px / np.sqrt(1 - fiber_e**2)
+                        fiber_orientation = row['fiber_orientation']
+                    else:
+                        logger.debug(f"Skipping outer ellipse for axon {idx}: invalid fiber_eccentricity value {fiber_e}")
+                        continue
+                else:
+                    logger.debug(f"Skipping outer ellipse for axon {idx}: missing fiber_eccentricity or fiber_orientation")
+                    continue
+                
+                outer_points = generate_rotated_ellipse_points(x0, y0, outer_semi_major_px, outer_semi_minor_px, fiber_orientation)
                 draw.polygon(outer_points, outline=255, width=line_width)
         elif axon_shape == 'circle':
             # Draw inner circle (axon diameter)

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -24,7 +24,7 @@ from AxonDeepSeg.apply_model import axon_segmentation
 from AxonDeepSeg.ads_utils import (convert_path, get_file_extension, 
                                    get_imshape, imwrite, imread)
 import AxonDeepSeg.ads_utils
-from AxonDeepSeg.params import valid_extensions, side_effect_suffixes
+from AxonDeepSeg.params import valid_extensions, generated_file_suffixes
 
 # Global variables
 DEFAULT_MODEL_NAME = "model_seg_generalist_light"
@@ -205,7 +205,7 @@ def segment_folder(
     img_files = [
         file for file in path_folder.iterdir() 
             if (file.suffix.lower() in valid_extensions)
-            and not str(file).endswith(side_effect_suffixes)
+            and not str(file).endswith(generated_file_suffixes)
     ]
 
     segment_images(img_files, path_model, gpu_id, verbosity_level)

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -374,6 +374,8 @@ The script to launch is called **axondeepseg_morphometrics**. It has several arg
 
 -n                  Computes morphometrics specific to **nerve sections** using the ``-n`` option. This enables analysis of axons **within nerve fascicle boundaries**, based on a segmentation mask with the suffix ``_seg-nerve.png``.
 
+-d                  Generate a diameter overlay image showing concentric circle or ellipse outlines for each myelinated axon (inner ring = axon boundary, outer ring = fiber boundary). Only available in myelinated mode (not compatible with ``-u`` or ``-n``). The axon shape used for the overlay matches the ``-a`` argument. Output is saved with the suffix ``_diameter_overlay.png``.
+
 Morphometrics of a single image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Before computing the morphometrics of an image, make sure it has been segmented using AxonDeepSeg ::
@@ -514,6 +516,29 @@ and their respective axon densities, as well as global area and total axon densi
         }
     }
     
+Diameter Overlay
+~~~~~~~~~~~~~~~~
+
+Using the ``-d`` flag generates a grayscale PNG image (``_diameter_overlay.png``) showing two concentric outlines per axon: an inner ring at the axon boundary and an outer ring at the fiber (axon+myelin) boundary. This is available for myelinated axons only and works with both ``-a circle`` and ``-a ellipse``.
+
+.. code-block:: bash
+
+   axondeepseg_morphometrics -i <IMAGE_PATH> -d
+
+.. code-block:: bash
+
+   axondeepseg_morphometrics -i <IMAGE_PATH> -a ellipse -d
+
+**Implementation note:** The outlines are *not* fits to the actual mask perimeters. They are ellipses (or circles) reconstructed from the second-moment (inertia-tensor) statistics of each region, as computed by ``skimage.measure.regionprops`` (centroid, eccentricity, orientation).
+
+For ``-a circle``: the inner radius is ``axon_diam / 2`` and the outer radius is ``axon_diam / 2 + myelin_thickness``. ``myelin_thickness`` is the true uniform ring thickness (difference in equivalent radii).
+
+For ``-a ellipse``: ``axon_diam`` is ``minor_axis_length`` from regionprops. The inner ellipse semi-minor axis is ``b = axon_diam / 2`` and the semi-major axis is derived as ``a = b / sqrt(1 - e²)`` from the axon eccentricity. The outer ellipse is derived independently from the axonmyelin regionprops (``fiber_eccentricity``, ``fiber_orientation``).
+
+.. warning::
+
+   In ellipse mode, ``myelin_thickness`` is defined as the difference in semi-minor axes between the axonmyelin and axon regions: ``(axonmyelin.minor_axis_length - axon.minor_axis_length) / 2``. This is the myelin thickness **along the minor axis only** — it is not a mean or uniform perimeter thickness. A true uniform sheath on an elliptical axon does not produce an elliptical outer boundary, so the inner and outer ellipses are modeled independently from their respective regionprops statistics. For circles (``-a circle``), the ring is uniform and ``myelin_thickness`` has its conventional meaning.
+
 Axon Shape: Circle vs Ellipse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -585,6 +610,10 @@ By default for axon shape, that is, `circle`, the equivalent diameter is used. F
      - Eccentricity of the ellipse that has the same second-moments as the axon region.
    * - orientation
      - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
+   * - fiber_eccentricity
+     - Eccentricity of the ellipse that has the same second-moments as the axon+myelin (fiber) region.
+   * - fiber_orientation
+     - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon+myelin (fiber) region.
    * - image_border_touching
      - Flag indicating if the axonmyelin objects touches the image border
    * - bbox_min_y

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -1097,3 +1097,34 @@ class TestCore(object):
             nerve_morph = json.load(f)
         assert 'total_axon_density' in nerve_morph.keys()
         assert 'axon_density' in nerve_morph['fascicle_areas']['0'].keys()
+
+    # --------------circle vs ellipse mode equivalence tests-------------- #
+    @pytest.mark.unit
+    def test_get_axon_morphometrics_axon_diam_equals_for_circle_and_ellipse_mode_when_shape_is_circle(self):
+        """For a perfect circle axon, circle and ellipse modes must report the same axon_diam."""
+        image_sim = SimulateAxons()
+        image_sim.generate_axon(axon_radius=40, center=[100, 100], gratio=0.7, plane_angle=0)
+
+        pred = image_sim.image
+        pred_axon = pred > 200
+        pred_myelin = np.logical_and(pred >= 50, pred <= 200)
+
+        df_circle = get_axon_morphometrics(pred_axon, im_myelin=pred_myelin, pixel_size=1.0, axon_shape='circle')
+        df_ellipse = get_axon_morphometrics(pred_axon, im_myelin=pred_myelin, pixel_size=1.0, axon_shape='ellipse')
+
+        assert df_circle['axon_diam'][0] == pytest.approx(df_ellipse['axon_diam'][0], rel=0.02)
+
+    @pytest.mark.unit
+    def test_get_axon_morphometrics_myelin_thickness_equals_for_circle_and_ellipse_mode_when_shape_is_circle(self):
+        """For a perfect circle axon, circle and ellipse modes must report the same myelin_thickness."""
+        image_sim = SimulateAxons()
+        image_sim.generate_axon(axon_radius=40, center=[100, 100], gratio=0.7, plane_angle=0)
+
+        pred = image_sim.image
+        pred_axon = pred > 200
+        pred_myelin = np.logical_and(pred >= 50, pred <= 200)
+
+        df_circle = get_axon_morphometrics(pred_axon, im_myelin=pred_myelin, pixel_size=1.0, axon_shape='circle')
+        df_ellipse = get_axon_morphometrics(pred_axon, im_myelin=pred_myelin, pixel_size=1.0, axon_shape='ellipse')
+
+        assert df_circle['myelin_thickness'][0] == pytest.approx(df_ellipse['myelin_thickness'][0], rel=0.02)

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -13,9 +13,9 @@ import AxonDeepSeg.ads_utils as ads
 from AxonDeepSeg.morphometrics.launch_morphometrics_computation import launch_morphometrics_computation
 from AxonDeepSeg.morphometrics.compute_morphometrics import load_axon_morphometrics
 from AxonDeepSeg.params import (
-    axonmyelin_suffix, axon_suffix, myelin_suffix, morph_suffix, 
+    axonmyelin_suffix, axon_suffix, myelin_suffix, morph_suffix,
     index_suffix, axonmyelin_index_suffix, instance_suffix, instance_im_suffix,
-    unmyelinated_suffix, unmyelinated_morph_suffix,
+    unmyelinated_suffix, unmyelinated_morph_suffix, diameter_overlay_suffix,
 )
 
 
@@ -58,6 +58,10 @@ class TestCore(object):
             (self.nerve_test_file.parent / 'image_nerve_index.png').unlink()
         if (self.nerve_test_file.parent / 'image_nerve_morphometrics.json').exists():
             (self.nerve_test_file.parent / 'image_nerve_morphometrics.json').unlink()
+
+        overlay_path = self.dataPath / f'image{diameter_overlay_suffix}'
+        if overlay_path.exists():
+            overlay_path.unlink()
 
     # --------------launch_morphometrics_computation tests-------------- #
     @pytest.mark.unit
@@ -381,6 +385,32 @@ class TestCore(object):
         assert output_nerve_morphometrics.exists()
         assert output_nerve_index.exists()
         assert output_nerve_morphometrics.read_text() == expected.read_text()
+
+    @pytest.mark.integration
+    def test_main_cli_creates_diameter_overlay_in_circle_mode(self):
+        pathImg = self.dataPath / 'image.png'
+        overlay_path = self.dataPath / f'image{diameter_overlay_suffix}'
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.morphometrics.launch_morphometrics_computation.main(
+                ["-i", str(pathImg), "-a", "circle", "-d"]
+            )
+
+        assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+        assert overlay_path.exists(), f"Expected diameter overlay at {overlay_path}"
+
+    @pytest.mark.integration
+    def test_main_cli_creates_diameter_overlay_in_ellipse_mode(self):
+        pathImg = self.dataPath / 'image.png'
+        overlay_path = self.dataPath / f'image{diameter_overlay_suffix}'
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.morphometrics.launch_morphometrics_computation.main(
+                ["-i", str(pathImg), "-a", "ellipse", "-d"]
+            )
+
+        assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+        assert overlay_path.exists(), f"Expected diameter overlay at {overlay_path}"
 
     @pytest.mark.integration
     def test_main_cli_throws_error_if_nerve_mode_without_axon_mask(self):

--- a/test/test_params.py
+++ b/test/test_params.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import pytest
+from pathlib import Path
 
 from AxonDeepSeg import params
 
@@ -32,3 +33,36 @@ class TestCore(object):
     def test_params_returns_expected_background(self):
         expected_value = 0
         assert params.intensity['background'] == expected_value
+
+    @pytest.mark.unit
+    def test_all_output_suffixes_excluded_from_folder_segmentation(self):
+        """
+        All known pipeline-generated file suffixes must be present in generated_file_suffixes.
+        The segmenter uses generated_file_suffixes to skip outputs when batch-processing a
+        folder; a missing suffix causes the segmenter to attempt to re-segment its own outputs.
+        If a new output suffix is added to params.py, add it here too.
+        """
+        expected = [
+            params.axonmyelin_suffix,
+            params.axon_suffix,
+            params.myelin_suffix,
+            params.index_suffix,
+            params.axonmyelin_index_suffix,
+            params.unmyelinated_suffix,
+            params.unmyelinated_index_suffix,
+            params.nnunet_suffix,
+            params.nerve_suffix,
+            params.nerve_index_suffix,
+            params.diameter_overlay_suffix,
+            params.instance_im_suffix,
+            params.instance_suffix,
+            params.morph_suffix,
+            params.morph_agg_suffix,
+            params.unmyelinated_morph_suffix,
+            params.nerve_morph_suffix,
+        ]
+        missing = [
+            str(s) for s in expected
+            if not str(s).endswith(params.generated_file_suffixes)
+        ]
+        assert missing == [], f"These output suffixes are not in generated_file_suffixes: {missing}"

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -3,7 +3,10 @@
 import pytest
 from pathlib import Path
 import numpy as np
+import pandas as pd
 from PIL import Image
+
+from skimage.measure import regionprops, label
 
 from AxonDeepSeg import ads_utils
 from AxonDeepSeg import postprocessing
@@ -104,6 +107,236 @@ class TestCore(object):
         # Load the created image and compare it to the expected image
         output_image = np.asarray(Image.open(output_image_path))
         assert np.array_equal(output_image, expected_image)
+
+    @pytest.mark.unit
+    def test_generate_rotated_ellipse_points_returns_requested_number_of_points(self):
+        points = postprocessing.generate_rotated_ellipse_points(
+            center_x=100, center_y=100, semi_major=20, semi_minor=10, orientation=0, num_points=64
+        )
+        assert len(points) == 64
+
+    @pytest.mark.unit
+    def test_generate_rotated_ellipse_points_circle_has_constant_radius(self):
+        """When semi_major == semi_minor, all points must be equidistant from the center."""
+        cx, cy, r = 50.0, 80.0, 15.0
+        points = postprocessing.generate_rotated_ellipse_points(
+            center_x=cx, center_y=cy, semi_major=r, semi_minor=r, orientation=0, num_points=128
+        )
+        distances = [np.hypot(x - cx, y - cy) for x, y in points]
+        assert np.allclose(distances, r, atol=1e-10)
+
+    @pytest.mark.unit
+    def test_generate_rotated_ellipse_points_extremal_points_match_axes(self):
+        """With orientation=0, the farthest point from center should be ~semi_major away."""
+        cx, cy = 0.0, 0.0
+        semi_major, semi_minor = 30.0, 10.0
+        points = postprocessing.generate_rotated_ellipse_points(
+            center_x=cx, center_y=cy, semi_major=semi_major, semi_minor=semi_minor,
+            orientation=0, num_points=1000
+        )
+        distances = [np.hypot(x - cx, y - cy) for x, y in points]
+        assert np.isclose(max(distances), semi_major, atol=1e-2)
+        assert np.isclose(min(distances), semi_minor, atol=1e-2)
+
+    @pytest.mark.unit
+    def test_generate_diameter_overlay_circle_enclosed_area_matches_axon_morphometric(self):
+        """
+        In circle mode, axon_diam = equivalent_diameter = sqrt(4*area/π), so the circle
+        drawn by the overlay encloses the same area as the axon mask.
+        Count enclosed pixels by checking that each non-outline pixel has outline pixels
+        on both sides in both x and y directions.
+        """
+        pixel_size = 0.1  # µm/px
+
+        # 50×50 square axon centered in a 200×200 image
+        mask = np.zeros((200, 200), dtype=np.uint8)
+        mask[75:125, 75:125] = 255
+        mask_area_px = int((mask > 0).sum())
+
+        # Derive axon_diam exactly as get_axon_morphometrics does in circle mode
+        props = regionprops(label(mask > 0))[0]
+        axon_diam_um = props.equivalent_diameter_area * pixel_size   # µm
+        cy, cx = props.centroid                                       # (row, col) → (y0, x0)
+
+        df = pd.DataFrame([{
+            'x0': cx, 'y0': cy,
+            'axon_diam': axon_diam_um,
+            'myelin_thickness': np.nan,
+        }])
+        overlay = postprocessing.generate_diameter_overlay(
+            df, image_shape=(200, 200), pixel_size=pixel_size, axon_shape='circle'
+        )
+
+        # A non-outline pixel is inside the circle if, in both x and y, there are
+        # outline pixels on both sides of it.
+        outline = overlay == 255
+        row_has_left  = np.cumsum(outline, axis=1) > 0
+        row_has_right = np.cumsum(outline[:, ::-1], axis=1)[:, ::-1] > 0
+        col_has_above = np.cumsum(outline, axis=0) > 0
+        col_has_below = np.cumsum(outline[::-1, :], axis=0)[::-1, :] > 0
+
+        inside = (~outline) & row_has_left & row_has_right & col_has_above & col_has_below
+        enclosed_area_px = int(inside.sum()) + int(outline.sum())
+
+        assert np.isclose(enclosed_area_px, mask_area_px, rtol=0.05)
+
+    @pytest.mark.unit
+    def test_generate_diameter_overlay_circle_inner_and_outer_are_concentric(self):
+        """Inner and outer rings must share the same center."""
+        pixel_size = 0.1
+        axon_diam = 10.0      # µm → inner radius = 50 px
+        myelin_thickness = 3.0  # µm → outer radius = 80 px
+        cx, cy = 200, 150
+        inner_radius_px = axon_diam / (2 * pixel_size)
+        outer_radius_px = inner_radius_px + myelin_thickness / pixel_size
+
+        df = pd.DataFrame([{
+            'x0': cx, 'y0': cy,
+            'axon_diam': axon_diam,
+            'myelin_thickness': myelin_thickness,
+        }])
+        overlay = postprocessing.generate_diameter_overlay(
+            df, image_shape=(400, 400), pixel_size=pixel_size, axon_shape='circle'
+        )
+
+        ys, xs = np.where(overlay > 0)
+        distances = np.hypot(xs - cx, ys - cy)
+        midpoint = (inner_radius_px + outer_radius_px) / 2
+        inner_mask = distances < midpoint
+        outer_mask = ~inner_mask
+
+        inner_center_x = np.mean(xs[inner_mask])
+        inner_center_y = np.mean(ys[inner_mask])
+        outer_center_x = np.mean(xs[outer_mask])
+        outer_center_y = np.mean(ys[outer_mask])
+
+        assert np.isclose(inner_center_x, outer_center_x, atol=1.0)
+        assert np.isclose(inner_center_y, outer_center_y, atol=1.0)
+
+    @pytest.mark.unit
+    def test_generate_diameter_overlay_ellipse_minor_axis_gap_matches_myelin_thickness(self):
+        """
+        In ellipse mode with orientation=0, the polygon vertex at index 0 falls exactly
+        at (cx + semi_minor, cy). The gap between the inner and outer outline centroids
+        along that horizontal line should equal myelin_thickness / pixel_size.
+        """
+        pixel_size = 0.1
+        axon_diam = 20.0        # µm → axon_radius_px = 100 px
+        myelin_thickness = 5.0  # µm → 50 px gap along minor axis
+        cx, cy = 300, 300
+        axon_radius_px = axon_diam / (2 * pixel_size)       # 100
+        myelin_thickness_px = myelin_thickness / pixel_size  # 50
+
+        df = pd.DataFrame([{
+            'x0': cx, 'y0': cy,
+            'axon_diam': axon_diam,
+            'myelin_thickness': myelin_thickness,
+            'eccentricity': 0.6,
+            'orientation': 0.0,
+            'fiber_eccentricity': 0.5,
+            'fiber_orientation': 0.0,
+        }])
+        overlay = postprocessing.generate_diameter_overlay(
+            df, image_shape=(600, 600), pixel_size=pixel_size, axon_shape='ellipse'
+        )
+
+        # With orientation=0, the first polygon vertex for each ellipse is placed at
+        # (cx + semi_minor, cy). Scan a ±3-pixel horizontal strip around cy for robustness.
+        strip_max = overlay[cy - 3:cy + 4, :].max(axis=0)
+        all_cols = np.arange(600)
+        right_lit_cols = all_cols[(strip_max > 0) & (all_cols > cx)]
+
+        # Split into inner cluster (≈cx+axon_radius_px) and outer (≈cx+outer_semi_minor)
+        midpoint_col = cx + axon_radius_px + myelin_thickness_px / 2
+        inner_cols = right_lit_cols[right_lit_cols < midpoint_col]
+        outer_cols = right_lit_cols[right_lit_cols >= midpoint_col]
+
+        gap_px = np.mean(outer_cols) - np.mean(inner_cols)
+        assert np.isclose(gap_px, myelin_thickness_px, atol=3.0)
+
+    @pytest.mark.unit
+    def test_generate_diameter_overlay_ellipse_equals_circle_enclosed_area_for_perfect_circle(self):
+        """
+        For a perfect circle (eccentricity=0), semi_major == semi_minor, so the ellipse
+        mode overlay is identical in shape to the circle mode overlay.
+        The total enclosed area (interior + outline) must agree within 2%.
+        """
+        pixel_size = 0.1
+        axon_diam = 10.0      # µm → radius = 50 px
+        myelin_thickness = 2.0  # µm → 20 px ring
+        cx, cy = 200, 200
+
+        base = {'x0': cx, 'y0': cy, 'axon_diam': axon_diam, 'myelin_thickness': myelin_thickness}
+
+        overlay_circle = postprocessing.generate_diameter_overlay(
+            pd.DataFrame([base]), image_shape=(400, 400), pixel_size=pixel_size, axon_shape='circle'
+        )
+        overlay_ellipse = postprocessing.generate_diameter_overlay(
+            pd.DataFrame([{**base, 'eccentricity': 0.0, 'orientation': 0.0,
+                           'fiber_eccentricity': 0.0, 'fiber_orientation': 0.0}]),
+            image_shape=(400, 400), pixel_size=pixel_size, axon_shape='ellipse'
+        )
+
+        def count_enclosed(overlay):
+            outline = overlay == 255
+            inside = (
+                (~outline)
+                & (np.cumsum(outline, axis=1) > 0)
+                & (np.cumsum(outline[:, ::-1], axis=1)[:, ::-1] > 0)
+                & (np.cumsum(outline, axis=0) > 0)
+                & (np.cumsum(outline[::-1, :], axis=0)[::-1, :] > 0)
+            )
+            return int(inside.sum()) + int(outline.sum())
+
+        assert np.isclose(count_enclosed(overlay_circle), count_enclosed(overlay_ellipse), rtol=0.02)
+
+    @pytest.mark.unit
+    def test_generate_diameter_overlay_ellipse_ring_gap_equals_circle_ring_gap_for_perfect_circle(self):
+        """
+        For a perfect circle (eccentricity=0), the ring gap measured from the ellipse
+        mode overlay should equal the gap from the circle mode overlay.
+        """
+        pixel_size = 0.1
+        axon_diam = 10.0      # µm → axon radius = 50 px
+        myelin_thickness = 2.0  # µm → 20 px ring
+        cx, cy = 200, 200
+        axon_radius_px = axon_diam / (2 * pixel_size)
+        myelin_thickness_px = myelin_thickness / pixel_size
+
+        base = {'x0': cx, 'y0': cy, 'axon_diam': axon_diam, 'myelin_thickness': myelin_thickness}
+
+        overlay_circle = postprocessing.generate_diameter_overlay(
+            pd.DataFrame([base]), image_shape=(400, 400), pixel_size=pixel_size, axon_shape='circle'
+        )
+        overlay_ellipse = postprocessing.generate_diameter_overlay(
+            pd.DataFrame([{**base, 'eccentricity': 0.0, 'orientation': 0.0,
+                           'fiber_eccentricity': 0.0, 'fiber_orientation': 0.0}]),
+            image_shape=(400, 400), pixel_size=pixel_size, axon_shape='ellipse'
+        )
+
+        def measure_right_gap(overlay):
+            # Scan a ±3-row strip at cy; split lit pixels right of cx into inner/outer clusters
+            strip_max = overlay[cy - 3:cy + 4, :].max(axis=0)
+            all_cols = np.arange(400)
+            right_lit = all_cols[(strip_max > 0) & (all_cols > cx)]
+            midpoint = cx + axon_radius_px + myelin_thickness_px / 2
+            return np.mean(right_lit[right_lit >= midpoint]) - np.mean(right_lit[right_lit < midpoint])
+
+        assert np.isclose(measure_right_gap(overlay_circle), measure_right_gap(overlay_ellipse), atol=3.0)
+
+    @pytest.mark.unit
+    def test_save_diameter_overlay_does_not_crash_and_creates_no_file_when_given_none(self, tmp_path):
+        output_path = tmp_path / 'overlay.png'
+        postprocessing.save_diameter_overlay(None, output_path)
+        assert not output_path.exists()
+
+    @pytest.mark.unit
+    def test_save_diameter_overlay_writes_file_for_valid_array(self, tmp_path):
+        overlay = np.zeros((100, 100), dtype=np.uint8)
+        overlay[50, 50] = 255
+        output_path = tmp_path / 'overlay.png'
+        postprocessing.save_diameter_overlay(overlay, output_path)
+        assert output_path.exists()
 
     @pytest.mark.unit
     def test_remove_axons_at_coordinates_returns_expected_masks(self):


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This feature allows us to visualize our area-based approximations for axon diameter and myelin thickness. A new `-d` option for the `axondeepseg_morphometrics` script triggers an additionnal output: an image suffixed _diameter_overlay_ (name is a WIP), with either circles or ellipses for every axon. For example, this segmentation:
<img width="1541" height="1096" alt="image_seg-axonmyelin" src="https://github.com/user-attachments/assets/3561545c-00fc-401b-95cd-0a8a03de7b22" />
Produces the following overlay for circle axon shape:
<img width="1541" height="1096" alt="image_diameter_overlay-CIRCLE" src="https://github.com/user-attachments/assets/753c29c0-01e1-4615-88f2-68b850531863" />
Or, when using the ellipse axon shape:
<img width="1541" height="1096" alt="image_diameter_overlay-ELLIPSE" src="https://github.com/user-attachments/assets/4bf19679-6f57-4628-a459-5b0d4c2515df" />

We can then make nice visualizations of the diameter approximation. For example, if we overlay this on top of the segmentation and the image:
<img width="1541" height="1096" alt="image_OVERLAY" src="https://github.com/user-attachments/assets/d65ac879-2b23-4422-916c-0ed54a73c9cc" />
