### PR TITLE
Napari dependency fix, add Mac x86_64 to test matrix & refactor some QT tests for compatibility

### DIFF
--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
+        os: [ "ubuntu-latest", "macos-latest", "macos-26-intel", "windows-latest"]
         python-version:  [ "3.11", "3.12"]
 
     # Main steps for the test to be reproduced across OS x Python

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -13,6 +13,7 @@ on:
     branches:
       - master
       - 'release/**'
+      - mb/macintel
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -13,7 +13,6 @@ on:
     branches:
       - master
       - 'release/**'
-      - mb/macintel
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -32,7 +32,6 @@ env:
   # (TravisCI quietly defined this on all their platforms, but we have to give it manually on GithubCI.)
   DEBIAN_FRONTEND: 'noninteractive'
   VISPY_GL_BACKEND: 'osmesa'
-  QT_QPA_PLATFORM: offscreen
 
 jobs:
   ultra_matrix_test:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - master
-      - mb/macintel
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - mb/macintel
 
   # Trigger current workflow on PR from ANY branch
   pull_request:
@@ -48,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
+        os: [ "ubuntu-latest", "macos-latest", "macos-26-intel", "windows-latest"]
         python-version: [ ">=3.11" ]
 
     # Main steps for the test to be reproduced across OS x Python

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -32,6 +32,7 @@ env:
   # (TravisCI quietly defined this on all their platforms, but we have to give it manually on GithubCI.)
   DEBIAN_FRONTEND: 'noninteractive'
   VISPY_GL_BACKEND: 'osmesa'
+  QT_QPA_PLATFORM: offscreen
 
 jobs:
   ultra_matrix_test:

--- a/install_ads
+++ b/install_ads
@@ -637,19 +637,16 @@ fi
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
 "$CONDA_DIR"/envs/venv_ads/bin/python -m pip install -U "pip!=21.2.*"
 
-## Pre-install numba/llvmlite via conda on Intel macOS only.
-## PyPI has no pre-built llvmlite wheels for x86_64 on newer macOS versions,
-## so pip falls back to a source build that breaks with setuptools>=70.1
-## (spawn() lost its dry_run kwarg). Conda always has pre-built binaries.
 ## Pre-install numba/llvmlite via pip on Intel macOS.
 ## llvmlite 0.46+ has no PyPI wheel for x86_64 (last was 0.45.1).
 ## numba 0.62.1 is the last version requiring llvmlite<0.46.
-## Both have x86_64 PyPI wheels and satisfy napari's numba>=0.57.1.
-## We use pip (not conda) so pip's resolver sees them as already installed.
+## We use a constraints file to prevent pip from upgrading them during
+## the main install (napari's numba>=0.57.1 would otherwise pull 0.64.0).
 if [[ "$OS" == "osx" ]] && [[ "$PROCESSOR" == "x86_64" ]]; then
   print info "Pre-installing numba/llvmlite via pip (Intel macOS workaround)..."
   SYSTEM_VERSION_COMPAT=0 "$CONDA_DIR"/envs/venv_ads/bin/pip install \
     "llvmlite==0.45.1" "numba==0.62.1"
+  printf 'llvmlite==0.45.1\nnumba==0.62.1\n' > /tmp/ads_intel_mac_constraints.txt
 fi
 
 ## Install the axondeepseg into the Conda venv
@@ -659,7 +656,20 @@ print info "Installing Python dependencies..."
 # We use 'SYSTEM_VERSION_COMPAT=0' to tell pip to report macOS 11 instead of macOS 10.16
 # This is necessary in order to install 'macosx_11_0' wheels. See also:
 # https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4352
-SYSTEM_VERSION_COMPAT=0 "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . --ignore-installed certifi && print info "Installing axondeepseg..." &&  "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . || die "Failed running pip install: $?"
+print info "Installing Python dependencies..."
+if [[ "$OS" == "osx" ]] && [[ "$PROCESSOR" == "x86_64" ]]; then
+  SYSTEM_VERSION_COMPAT=0 "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . \
+    -c /tmp/ads_intel_mac_constraints.txt && \
+    print info "Installing axondeepseg..." && \
+    "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . \
+      -c /tmp/ads_intel_mac_constraints.txt || die "Failed running pip install: $?"
+else
+  SYSTEM_VERSION_COMPAT=0 "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . \
+    --ignore-installed certifi && \
+    print info "Installing axondeepseg..." && \
+    "$CONDA_DIR"/envs/venv_ads/bin/pip install -e . || die "Failed running pip install: $?"
+fi
+
 print info "All requirements installed!"
 
 ## Create launchers for Python scripts

--- a/install_ads
+++ b/install_ads
@@ -643,7 +643,7 @@ fi
 ## (spawn() lost its dry_run kwarg). Conda always has pre-built binaries.
 if [[ "$OS" == "osx" ]] && [[ "$PROCESSOR" == "x86_64" ]]; then
   print info "Pre-installing numba via conda (Intel macOS workaround)..."
-  "$CONDA_DIR"/bin/conda install -y -p "$ADS_DIR/$CONDA_DIR/envs/venv_ads" -c conda-forge numba
+  "$CONDA_DIR"/bin/conda install -y -p "$ADS_DIR/$CONDA_DIR/envs/venv_ads" -c conda-forge "numba" "numpy<2"
 fi
 
 ## Install the axondeepseg into the Conda venv

--- a/install_ads
+++ b/install_ads
@@ -641,9 +641,15 @@ fi
 ## PyPI has no pre-built llvmlite wheels for x86_64 on newer macOS versions,
 ## so pip falls back to a source build that breaks with setuptools>=70.1
 ## (spawn() lost its dry_run kwarg). Conda always has pre-built binaries.
+## Pre-install numba/llvmlite via pip on Intel macOS.
+## llvmlite 0.46+ has no PyPI wheel for x86_64 (last was 0.45.1).
+## numba 0.62.1 is the last version requiring llvmlite<0.46.
+## Both have x86_64 PyPI wheels and satisfy napari's numba>=0.57.1.
+## We use pip (not conda) so pip's resolver sees them as already installed.
 if [[ "$OS" == "osx" ]] && [[ "$PROCESSOR" == "x86_64" ]]; then
-  print info "Pre-installing numba via conda (Intel macOS workaround)..."
-  "$CONDA_DIR"/bin/conda install -y -p "$ADS_DIR/$CONDA_DIR/envs/venv_ads" -c conda-forge "numba" "numpy<2"
+  print info "Pre-installing numba/llvmlite via pip (Intel macOS workaround)..."
+  SYSTEM_VERSION_COMPAT=0 "$CONDA_DIR"/envs/venv_ads/bin/pip install \
+    "llvmlite==0.45.1" "numba==0.62.1"
 fi
 
 ## Install the axondeepseg into the Conda venv

--- a/install_ads
+++ b/install_ads
@@ -585,14 +585,14 @@ linux)
   if [[ "$PROCESSOR" == "aarch64" ]] ; then
     download "$TMP_DIR/"miniconda.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
   else
-    download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    download "$TMP_DIR/"miniconda.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
   fi
   ;;
 osx)
   if [[ "$PROCESSOR" == "arm64" ]] ; then
     download "$TMP_DIR/"miniconda.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
   else
-    download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+    download "$TMP_DIR/"miniconda.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh
   fi
   ;;
 esac

--- a/install_ads
+++ b/install_ads
@@ -637,6 +637,15 @@ fi
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
 "$CONDA_DIR"/envs/venv_ads/bin/python -m pip install -U "pip!=21.2.*"
 
+## Pre-install numba/llvmlite via conda on Intel macOS only.
+## PyPI has no pre-built llvmlite wheels for x86_64 on newer macOS versions,
+## so pip falls back to a source build that breaks with setuptools>=70.1
+## (spawn() lost its dry_run kwarg). Conda always has pre-built binaries.
+if [[ "$OS" == "osx" ]] && [[ "$PROCESSOR" == "x86_64" ]]; then
+  print info "Pre-installing numba via conda (Intel macOS workaround)..."
+  "$CONDA_DIR"/bin/conda install -y -p "$ADS_DIR/$CONDA_DIR/envs/venv_ads" -c conda-forge numba
+fi
+
 ## Install the axondeepseg into the Conda venv
 print info "Installing Python dependencies..."
 # We use "--ignore-installed" to preserve the version of `certifi` installed into the conda

--- a/test/ads_napari/test_widget.py
+++ b/test/ads_napari/test_widget.py
@@ -328,9 +328,9 @@ class TestCore(object):
     
             ## Simulate Show Axon Morphometris button click
             with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
-                with patch("PyQt5.QtWidgets.QInputDialog.getDouble", return_value=(0.07, True)):
+                with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.get_pixel_size_with_prompt", return_value=0.07):
                     with tempfile.NamedTemporaryFile(prefix='Morphometrics', suffix='.csv', delete=False) as temp_file:
-                        with patch("PyQt5.QtWidgets.QFileDialog.getSaveFileName", return_value=(temp_file.name, None)):
+                        with patch("AxonDeepSeg.ads_napari._widget.QFileDialog.getSaveFileName", return_value=(temp_file.name, None)):
                             # Simulate a button click
                             QTest.mouseClick(wdg.show_axon_metrics_button, Qt.LeftButton)
 

--- a/test/ads_napari/test_widget.py
+++ b/test/ads_napari/test_widget.py
@@ -174,7 +174,7 @@ class TestCore(object):
             # Do nothing
     
             # Assert that image_loaded_after_plugin_start state changed
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 QTest.mouseClick(wdg.remove_axons_button, Qt.LeftButton)
             
             assert wdg.remove_axon_state == False
@@ -204,7 +204,7 @@ class TestCore(object):
             wdg._on_layer_added(ImageLoadedEvent(imread(self.image_path)))
     
             # Assert that image_loaded_after_plugin_start state changed
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 QTest.mouseClick(wdg.remove_axons_button, Qt.LeftButton)
             
             assert wdg.remove_axon_state == False
@@ -248,7 +248,7 @@ class TestCore(object):
             assert wdg.im_axonmyelin_label is None
     
             ## Simulate Remove Axons button click
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 # Simulate a button click
                 QTest.mouseClick(wdg.remove_axons_button, Qt.LeftButton)
     
@@ -282,7 +282,7 @@ class TestCore(object):
             wdg._on_layer_added(ImageLoadedEvent(imread(self.image_path)))
     
             # Assert that image_loaded_after_plugin_start state changed
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 QTest.mouseClick(wdg.show_axon_metrics_button, Qt.LeftButton)
             
             assert wdg.show_axon_metrics_state == False
@@ -327,7 +327,7 @@ class TestCore(object):
             assert wdg.im_axonmyelin_label is None
     
             ## Simulate Show Axon Morphometris button click
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 with patch("PyQt5.QtWidgets.QInputDialog.getDouble", return_value=(0.07, True)):
                     with tempfile.NamedTemporaryFile(prefix='Morphometrics', suffix='.csv', delete=False) as temp_file:
                         with patch("PyQt5.QtWidgets.QFileDialog.getSaveFileName", return_value=(temp_file.name, None)):
@@ -379,7 +379,7 @@ class TestCore(object):
             assert wdg.im_axonmyelin_label is None
     
             ## Simulate Show Axon Morphometris button click
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 with patch("PyQt5.QtWidgets.QInputDialog.getDouble", return_value=(0.07, False)):
                         # Simulate a button click
                         QTest.mouseClick(wdg.show_axon_metrics_button, Qt.LeftButton)

--- a/test/ads_napari/test_widget.py
+++ b/test/ads_napari/test_widget.py
@@ -415,7 +415,7 @@ class TestCore(object):
             wdg = ADSplugin(viewer)
             
             ## User loads image
-            with patch("PyQt5.QtWidgets.QMessageBox.exec", return_value=QMessageBox.Ok):
+            with patch("AxonDeepSeg.ads_napari._widget.ADSplugin.show_info_message", return_value=True):
                 viewer.add_image(large_image, rgb=False)
     
             wdg._on_layer_added(ImageLoadedEvent(imread(self.image_path)))


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

* Added mac x86_64 runners to both test matrices
* Fixed an LLVM-lite compatibility issue by installing prior to napari & locking the versions installed
* Refactors some QT test `while` conditions as they would hang on x_86_64, likely due to how the backend is handled

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #964 and #965 