### PR TITLE
Add light Stanford model

### DIFF
--- a/AxonDeepSeg/model_cards.yaml
+++ b/AxonDeepSeg/model_cards.yaml
@@ -51,4 +51,4 @@ unmyelinated-TEM:
   training-data: Available at https://dandiarchive.org/dandiset/001350?pos=4
   weights:
     ensemble: https://github.com/axondeepseg-pipeline/model_seg_unmyelinated_tem/releases/download/r20240708-stanford/model_seg_unmyelinated_stanford_tem_best.zip
-    single_fold: ~
+    single_fold: https://github.com/axondeepseg-pipeline/model_seg_unmyelinated_tem/releases/download/v2.0.0/model_seg_unmyelinated_tem_light.zip


### PR DESCRIPTION
## Description
Simple addition of a lighter Stanford model (unmyelinated-TEM), which is 5x smaller than the current default one (and 5x faster).

@yolaatar just letting you know I added this, because I know you used this model a few times. Now, the `download_model` command should download this lighter model by default.