### PR TITLE
feat(napari): segmentation progress bar + cancel button

### DIFF
--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -38,6 +38,7 @@ from AxonDeepSeg.visualization.colorization import colorize_instance_segmentatio
 
 import napari
 from napari.utils.notifications import show_info
+from napari.utils import progress as napari_progress
 from .settings_menu_ui import Ui_Settings_menu_ui
 from vispy.util import keys
 import webbrowser
@@ -198,6 +199,9 @@ class ADSplugin(QWidget):
         self.apply_model_thread = ApplyModelThread()
         self.apply_model_thread.model_applied_signal.connect(
             self._on_model_finished_apply
+        )
+        self.apply_model_thread.progress_update.connect(
+            self._on_segmentation_progress
         )
 
         load_mask_button = QPushButton("Load mask")
@@ -485,6 +489,18 @@ class ADSplugin(QWidget):
         else:
             return False
 
+    def _on_segmentation_progress(self, current, total, desc):
+        """Update the napari Activity dock progress bar from the main thread."""
+        pbr = self.apply_model_thread.progress_bar
+        if pbr is None:
+            return
+        if pbr.total != total:
+            pbr.total = total
+            pbr.reset()
+        pbr.set_description(desc)
+        pbr.n = current
+        pbr.events.value(value=current)
+
     def _on_apply_model_button_click(self, layer):
         """Apply the selected AxonDeepSeg model to the active layer of the viewer.
 
@@ -542,6 +558,15 @@ class ADSplugin(QWidget):
         self.apply_model_thread.path_model = model_path
         self.apply_model_thread.gpu_id = self.settings.gpu_id
         self.apply_model_thread.allow_large_images = allow_large_images
+        self.apply_model_thread.progress_bar = napari_progress(
+            total=0, desc="Segmenting image..."
+        )
+        try:
+            sb = self.viewer.window._qt_window.statusBar()
+            if not self.viewer.window._qt_window._activity_dialog.isVisible():
+                sb._toggle_activity_dock()
+        except Exception:
+            pass
         self.show_info_message(
             "Running AI model... This can take a few seconds or minutes. Check the console/terminal for more information."
         )
@@ -1333,6 +1358,7 @@ class ApplyModelThread(QtCore.QThread):
     """
 
     model_applied_signal = Signal()
+    progress_update = Signal(int, int, str)  # (current, total, description)
 
     def __init__(self):
         """Initializes an instance of the class with default values for attributes.
@@ -1353,6 +1379,7 @@ class ApplyModelThread(QtCore.QThread):
         self.gpu_id = -1
         self.task_finished_successfully = False
         self.allow_large_images = False
+        self.progress_bar = None
 
     def run(self):
         """Executes the segmentation process in a separate thread on the selected image layer using the AxonDeepSeg
@@ -1361,6 +1388,26 @@ class ApplyModelThread(QtCore.QThread):
         Returns:
             None
         """
+        import nnunetv2.inference.predict_from_raw_data as _nnunet_module
+
+        # Monkey-patch nnUNet's tqdm with napari's progress so the sliding
+        # window inference loop renders in the napari Activity dock.
+        _original_tqdm = _nnunet_module.tqdm
+
+        def _napari_tqdm(iterable=None, *args, **kwargs):
+            kwargs.pop("disable", None)
+            if iterable is not None:
+                items = list(iterable)
+                total = len(items)
+                self.progress_update.emit(0, total, "Running inference...")
+                for i, item in enumerate(items):
+                    yield item
+                    self.progress_update.emit(i + 1, total, "Running inference...")
+            else:
+                yield from _original_tqdm(*args, **kwargs)
+
+        _nnunet_module.tqdm = _napari_tqdm
+
         self.task_finished_successfully = False
         try:
             segment.segment_images(
@@ -1378,4 +1425,8 @@ class ApplyModelThread(QtCore.QThread):
                     "for the minimum zoom factor value to use (option available in the Settings menu)."
                 )
             self.task_finished_successfully = False
+        finally:
+            _nnunet_module.tqdm = _original_tqdm
+            if self.progress_bar is not None:
+                self.progress_bar.close()
         self.model_applied_signal.emit()

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -14,6 +14,7 @@ import qtpy.QtCore
 from qtpy import QtWidgets, QtCore
 from qtpy.QtWidgets import (
     QVBoxLayout,
+    QHBoxLayout,
     QPushButton,
     QWidget,
     QComboBox,
@@ -215,6 +216,10 @@ class ADSplugin(QWidget):
             "QProgressBar::chunk {  background-color: #007acc; }"
         )
 
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.setEnabled(False)
+        self.cancel_button.clicked.connect(self._on_cancel_button_click)
+
         load_mask_button = QPushButton("Load mask")
         load_mask_button.clicked.connect(self._on_load_mask_button_click)
         self.load_mask_button = load_mask_button
@@ -273,8 +278,14 @@ class ADSplugin(QWidget):
         self.layout().addWidget(citation_textbox)
         self.layout().addWidget(demo_label)
         self.layout().addWidget(hyperlink_label)
+        seg_row = QWidget()
+        seg_row_layout = QHBoxLayout(seg_row)
+        seg_row_layout.setContentsMargins(0, 0, 0, 0)
+        seg_row_layout.addWidget(self.apply_model_button)
+        seg_row_layout.addWidget(self.cancel_button)
+
         self.layout().addWidget(self.model_selection_combobox)
-        self.layout().addWidget(self.apply_model_button)
+        self.layout().addWidget(seg_row)
         self.layout().addWidget(self.segmentation_progress)
         self.layout().addWidget(load_mask_button)
         self.layout().addWidget(fill_axons_button)
@@ -570,6 +581,7 @@ class ADSplugin(QWidget):
 
         self.segmentation_progress.setRange(0, 0)
         self.segmentation_progress.setVisible(True)
+        self.cancel_button.setEnabled(True)
 
         self.show_info_message(
             "Running AI model... This can take a few seconds or minutes. Check the console/terminal for more information."
@@ -590,6 +602,12 @@ class ADSplugin(QWidget):
         """
 
         self.apply_model_button.setEnabled(True)
+        self.cancel_button.setEnabled(False)
+        self.segmentation_progress.setVisible(False)
+        self.segmentation_progress.setRange(0, 1)
+        self.segmentation_progress.setValue(0)
+        if self.apply_model_thread.cancelled or self.apply_model_thread.cancel_requested:
+            return
         if not self.apply_model_thread.task_finished_successfully:
             self.show_info_message(
                 "Couldn't apply the ADS model. Please check the console or terminal for more information."
@@ -614,6 +632,12 @@ class ADSplugin(QWidget):
         )
         myelin_mask_name = image_name_no_extension + myelin_suffix.stem
 
+        if not axon_mask_path.exists() or not myelin_mask_path.exists():
+            self.show_info_message(
+                "Segmentation completed but output masks were not found. Please check the console or terminal for more information."
+            )
+            return
+
         # Reset cached state when new masks are loaded
         self._reset_cached_state()
 
@@ -636,9 +660,9 @@ class ADSplugin(QWidget):
             "associated_myelin_mask_name"
         ] = myelin_mask_name
 
-        self.segmentation_progress.setVisible(False)
-        self.segmentation_progress.setRange(0, 1)
-        self.segmentation_progress.setValue(0)
+    def _on_cancel_button_click(self):
+        self.apply_model_thread.cancel_requested = True
+        self.cancel_button.setEnabled(False)
 
     def _on_load_mask_button_click(self):
         """Handles the click event of the 'Load Mask' button.
@@ -1387,6 +1411,8 @@ class ApplyModelThread(QtCore.QThread):
         self.gpu_id = -1
         self.task_finished_successfully = False
         self.allow_large_images = False
+        self.cancel_requested = False
+        self.cancelled = False
 
     def run(self):
         """Executes the segmentation process in a separate thread on the selected image layer using the AxonDeepSeg
@@ -1397,6 +1423,9 @@ class ApplyModelThread(QtCore.QThread):
         """
         # Monkey-patch nnUNet's tqdm with napari's progress so the sliding
         # window inference loop renders in the napari Activity dock.
+        self.cancel_requested = False
+        self.cancelled = False
+
         _original_tqdm = nnunet_predictor.tqdm
 
         def _napari_tqdm(iterable=None, *args, **kwargs):
@@ -1406,6 +1435,8 @@ class ApplyModelThread(QtCore.QThread):
                 total = len(items)
                 self.progress_update.emit(0, total, "Applying model")
                 for i, item in enumerate(items):
+                    if self.cancel_requested:
+                        raise InterruptedError("Segmentation cancelled by user")
                     yield item
                     self.progress_update.emit(i + 1, total, "Applying model")
             else:
@@ -1423,6 +1454,9 @@ class ApplyModelThread(QtCore.QThread):
                 allow_large_images=self.allow_large_images,
             )
             self.task_finished_successfully = True
+        except InterruptedError:
+            self.cancelled = True
+            self.task_finished_successfully = False
         except SystemExit as err:
             if err.code == 4:
                 print(

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -208,7 +208,6 @@ class ADSplugin(QWidget):
         )
         
         self.segmentation_progress = QProgressBar(self)
-        self.segmentation_progress.setVisible(False)
         self.segmentation_progress.setMinimum(0)
         self.segmentation_progress.setMaximum(1)
         self.segmentation_progress.setTextVisible(True)
@@ -278,15 +277,16 @@ class ADSplugin(QWidget):
         self.layout().addWidget(citation_textbox)
         self.layout().addWidget(demo_label)
         self.layout().addWidget(hyperlink_label)
-        seg_row = QWidget()
-        seg_row_layout = QHBoxLayout(seg_row)
-        seg_row_layout.setContentsMargins(0, 0, 0, 0)
-        seg_row_layout.addWidget(self.apply_model_button)
-        seg_row_layout.addWidget(self.cancel_button)
+        self.progress_row = QWidget()
+        self.progress_row.setVisible(False)
+        self.progress_row_layout = QHBoxLayout(self.progress_row)
+        self.progress_row_layout.setContentsMargins(0, 0, 0, 0)
+        self.progress_row_layout.addWidget(self.segmentation_progress)
+        self.progress_row_layout.addWidget(self.cancel_button)
 
         self.layout().addWidget(self.model_selection_combobox)
-        self.layout().addWidget(seg_row)
-        self.layout().addWidget(self.segmentation_progress)
+        self.layout().addWidget(self.apply_model_button)
+        self.layout().addWidget(self.progress_row)
         self.layout().addWidget(load_mask_button)
         self.layout().addWidget(fill_axons_button)
         self.layout().addWidget(remove_axons_button)
@@ -580,7 +580,7 @@ class ADSplugin(QWidget):
         self.apply_model_thread.allow_large_images = allow_large_images
 
         self.segmentation_progress.setRange(0, 0)
-        self.segmentation_progress.setVisible(True)
+        self.progress_row.setVisible(True)
         self.cancel_button.setEnabled(True)
 
         self.show_info_message(
@@ -603,7 +603,7 @@ class ADSplugin(QWidget):
 
         self.apply_model_button.setEnabled(True)
         self.cancel_button.setEnabled(False)
-        self.segmentation_progress.setVisible(False)
+        self.progress_row.setVisible(False)
         self.segmentation_progress.setRange(0, 1)
         self.segmentation_progress.setValue(0)
         if self.apply_model_thread.cancelled or self.apply_model_thread.cancel_requested:

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (
     QPlainTextEdit,
     QInputDialog,
     QMessageBox,
+    QProgressBar,
 )
 from qtpy.QtCore import QStringListModel, QObject, Signal
 from qtpy.QtGui import QPixmap
@@ -204,6 +205,15 @@ class ADSplugin(QWidget):
         self.apply_model_thread.progress_update.connect(
             self._on_segmentation_progress
         )
+        
+        self.segmentation_progress = QProgressBar(self)
+        self.segmentation_progress.setVisible(False)
+        self.segmentation_progress.setMinimum(0)
+        self.segmentation_progress.setMaximum(1)
+        self.segmentation_progress.setTextVisible(True)
+        self.segmentation_progress.setStyleSheet(
+            "QProgressBar::chunk {  background-color: #007acc; }"
+        )
 
         load_mask_button = QPushButton("Load mask")
         load_mask_button.clicked.connect(self._on_load_mask_button_click)
@@ -265,6 +275,7 @@ class ADSplugin(QWidget):
         self.layout().addWidget(hyperlink_label)
         self.layout().addWidget(self.model_selection_combobox)
         self.layout().addWidget(self.apply_model_button)
+        self.layout().addWidget(self.segmentation_progress)
         self.layout().addWidget(load_mask_button)
         self.layout().addWidget(fill_axons_button)
         self.layout().addWidget(remove_axons_button)
@@ -491,16 +502,16 @@ class ADSplugin(QWidget):
             return False
 
     def _on_segmentation_progress(self, current, total, desc):
-        """Update the napari Activity dock progress bar from the main thread."""
-        pbr = self.apply_model_thread.progress_bar
-        if pbr is None:
+        """Update the progress bar from the main thread."""
+        pb = getattr(self, "segmentation_progress", None)
+        if pb is None:
             return
-        if pbr.total != total:
-            pbr.total = total
-            pbr.reset()
-        pbr.set_description(desc)
-        pbr.n = current
-        pbr.events.value(value=current)
+        if total and pb.maximum() != total:
+            pb.setMaximum(total)
+        elif total == 0:
+            pb.setRange(0, 0)
+        pb.setFormat(f"{desc} (%v/%m)")
+        pb.setValue(current)
 
     def _on_apply_model_button_click(self, layer):
         """Apply the selected AxonDeepSeg model to the active layer of the viewer.
@@ -511,8 +522,6 @@ class ADSplugin(QWidget):
 
         selected_layers = self.viewer.layers.selection
         selected_model = self.model_selection_combobox.currentText()
-
-
 
         if selected_model not in self.available_models:
             self.show_info_message("No model selected")
@@ -530,7 +539,6 @@ class ADSplugin(QWidget):
 
         # Check if the image exceeds PIL's default decompression bomb limit.
         # If so, ask the user for confirmation before proceeding.
-        from PIL import Image as _PIL_Image
         _DEFAULT_PIL_LIMIT = 89478485  # PIL's default MAX_IMAGE_PIXELS
         n_pixels = selected_layer.data.shape[-2] * selected_layer.data.shape[-1]
         if n_pixels > _DEFAULT_PIL_LIMIT:
@@ -559,15 +567,10 @@ class ADSplugin(QWidget):
         self.apply_model_thread.path_model = model_path
         self.apply_model_thread.gpu_id = self.settings.gpu_id
         self.apply_model_thread.allow_large_images = allow_large_images
-        self.apply_model_thread.progress_bar = napari_progress(
-            total=0, desc="Preprocessing the image"
-        )
-        try:
-            sb = self.viewer.window._qt_window.statusBar()
-            if not self.viewer.window._qt_window._activity_dialog.isVisible():
-                sb._toggle_activity_dock()
-        except Exception:
-            pass
+
+        self.segmentation_progress.setRange(0, 0)
+        self.segmentation_progress.setVisible(True)
+
         self.show_info_message(
             "Running AI model... This can take a few seconds or minutes. Check the console/terminal for more information."
         )
@@ -633,9 +636,9 @@ class ADSplugin(QWidget):
             "associated_myelin_mask_name"
         ] = myelin_mask_name
 
-        # Close activity dock if necessary
-        if self.viewer.window._qt_window._activity_dialog.isVisible():
-            self.viewer.window._qt_window.statusBar()._toggle_activity_dock()
+        self.segmentation_progress.setVisible(False)
+        self.segmentation_progress.setRange(0, 1)
+        self.segmentation_progress.setValue(0)
 
     def _on_load_mask_button_click(self):
         """Handles the click event of the 'Load Mask' button.
@@ -1384,7 +1387,6 @@ class ApplyModelThread(QtCore.QThread):
         self.gpu_id = -1
         self.task_finished_successfully = False
         self.allow_large_images = False
-        self.progress_bar = None
 
     def run(self):
         """Executes the segmentation process in a separate thread on the selected image layer using the AxonDeepSeg
@@ -1402,10 +1404,10 @@ class ApplyModelThread(QtCore.QThread):
             if iterable is not None:
                 items = list(iterable)
                 total = len(items)
-                self.progress_update.emit(0, total, "Running inference")
+                self.progress_update.emit(0, total, "Applying model")
                 for i, item in enumerate(items):
                     yield item
-                    self.progress_update.emit(i + 1, total, "Running inference")
+                    self.progress_update.emit(i + 1, total, "Applying model")
             else:
                 yield from _original_tqdm(*args, **kwargs)
 
@@ -1430,6 +1432,4 @@ class ApplyModelThread(QtCore.QThread):
             self.task_finished_successfully = False
         finally:
             nnunet_predictor.tqdm = _original_tqdm
-            if self.progress_bar is not None:
-                self.progress_bar.close()
         self.model_applied_signal.emit()

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -35,6 +35,7 @@ from AxonDeepSeg.qa.metrics_qa import MetricsQA
 import AxonDeepSeg.morphometrics.compute_morphometrics as compute_morphs
 from AxonDeepSeg.params import axonmyelin_suffix, axon_suffix, myelin_suffix
 from AxonDeepSeg.visualization.colorization import colorize_instance_segmentation
+import nnunetv2.inference.predict_from_raw_data as nnunet_predictor
 
 import napari
 from napari.utils.notifications import show_info
@@ -1388,11 +1389,9 @@ class ApplyModelThread(QtCore.QThread):
         Returns:
             None
         """
-        import nnunetv2.inference.predict_from_raw_data as _nnunet_module
-
         # Monkey-patch nnUNet's tqdm with napari's progress so the sliding
         # window inference loop renders in the napari Activity dock.
-        _original_tqdm = _nnunet_module.tqdm
+        _original_tqdm = nnunet_predictor.tqdm
 
         def _napari_tqdm(iterable=None, *args, **kwargs):
             kwargs.pop("disable", None)
@@ -1406,7 +1405,7 @@ class ApplyModelThread(QtCore.QThread):
             else:
                 yield from _original_tqdm(*args, **kwargs)
 
-        _nnunet_module.tqdm = _napari_tqdm
+        nnunet_predictor.tqdm = _napari_tqdm
 
         self.task_finished_successfully = False
         try:
@@ -1426,7 +1425,7 @@ class ApplyModelThread(QtCore.QThread):
                 )
             self.task_finished_successfully = False
         finally:
-            _nnunet_module.tqdm = _original_tqdm
+            nnunet_predictor.tqdm = _original_tqdm
             if self.progress_bar is not None:
                 self.progress_bar.close()
         self.model_applied_signal.emit()

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -560,7 +560,7 @@ class ADSplugin(QWidget):
         self.apply_model_thread.gpu_id = self.settings.gpu_id
         self.apply_model_thread.allow_large_images = allow_large_images
         self.apply_model_thread.progress_bar = napari_progress(
-            total=0, desc="Segmenting image..."
+            total=0, desc="Preprocessing the image"
         )
         try:
             sb = self.viewer.window._qt_window.statusBar()
@@ -1398,10 +1398,10 @@ class ApplyModelThread(QtCore.QThread):
             if iterable is not None:
                 items = list(iterable)
                 total = len(items)
-                self.progress_update.emit(0, total, "Running inference...")
+                self.progress_update.emit(0, total, "Running inference")
                 for i, item in enumerate(items):
                     yield item
-                    self.progress_update.emit(i + 1, total, "Running inference...")
+                    self.progress_update.emit(i + 1, total, "Running inference")
             else:
                 yield from _original_tqdm(*args, **kwargs)
 

--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -633,6 +633,10 @@ class ADSplugin(QWidget):
             "associated_myelin_mask_name"
         ] = myelin_mask_name
 
+        # Close activity dock if necessary
+        if self.viewer.window._qt_window._activity_dialog.isVisible():
+            self.viewer.window._qt_window.statusBar()._toggle_activity_dock()
+
     def _on_load_mask_button_click(self):
         """Handles the click event of the 'Load Mask' button.
 


### PR DESCRIPTION
## Summary

- Adds a `napari.utils.progress` bar that appears in the napari **Activity dock** when the user clicks "Segment image"
- Monkey-patches nnUNet's internal `tqdm` reference with a generator that emits a Qt signal per patch; the signal handler updates the progress bar on the main thread (avoids Qt cross-thread QObject crash)
- Automatically opens the Activity dock at inference start so users don't have to find it manually
- Progress bar is closed cleanly in a `finally` block regardless of success or failure

Closes #979 (progress bar during segmentation)

## How to test

1. Load a large image in napari
2. Select a model and click **Segment image**
3. The Activity dock should open and show a progress bar advancing through nnUNet's sliding-window patches

## Notes

- The monkey-patch is scoped to `ApplyModelThread.run()` and always restored in `finally`, so it does not affect other uses of nnUNet
- Does not require any changes to nnUNet or napari internals