### PR TITLE
fix: --allow-large-images flag not applied in get_imshape

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -119,7 +119,7 @@ def imread(filename, use_16bit=False, allow_large_images=False):
                                f"file extensions:  '.png', '.tif', '.tiff', '.jpg' and '.jpeg'.")
 
     # Check if the image exceeds PIL's decompression bomb pixel limit.
-    shape = get_imshape(filename)
+    shape = get_imshape(filename, allow_large_images=allow_large_images)
     n_pixels = shape[0] * shape[1]
     if Image.MAX_IMAGE_PIXELS is not None and n_pixels > Image.MAX_IMAGE_PIXELS:
         if not allow_large_images:
@@ -249,10 +249,16 @@ def get_file_extension(filename):
     extension = next((ext for ext in valid_extensions if str(filename).lower().endswith(ext)), None)
     return extension
 
-def get_imshape(filename: str):
+def get_imshape(filename: str, allow_large_images: bool = False):
     """Get the shape of an image (HWC format) without reading its data.
     """
-    shape = imageio.v3.improps(filename).shape
+    old_limit = Image.MAX_IMAGE_PIXELS
+    if allow_large_images:
+        Image.MAX_IMAGE_PIXELS = _LARGE_IMAGE_PIXEL_LIMIT
+    try:
+        shape = imageio.v3.improps(filename).shape
+    finally:
+        Image.MAX_IMAGE_PIXELS = old_limit
     if len(shape) == 2:
         shape = (shape[0], shape[1], 1)
     return shape

--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -19,7 +19,7 @@ from loguru import logger
 from AxonDeepSeg.params import valid_extensions
 import re
 
-# Raised pixel limit for large scientific images (e.g. TEM whole-slide acquisitions).
+# Raised pixel limit for large scientific images.
 # PIL's default is ~178M pixels; 1B pixels accommodates most microscopy use cases.
 _LARGE_IMAGE_PIXEL_LIMIT = 1_000_000_000
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -95,7 +95,7 @@ def prepare_inputs(path_imgs: List[Path], file_format: str, n_channels: int, all
     for im_path in path_imgs:
         target = im_path
 
-        imshape = get_imshape(str(target)) # HWC format
+        imshape = get_imshape(str(target), allow_large_images=allow_large_images)
         is_correct_shape = (imshape[-1] == n_channels)
         is_correct_format = (target.suffix == file_format)
         needs_conversion = (is_correct_shape == False) or (is_correct_format == False)

--- a/test/test_ads_utils.py
+++ b/test/test_ads_utils.py
@@ -7,7 +7,6 @@ import imageio
 import os
 
 import pytest
-from unittest.mock import patch
 
 import AxonDeepSeg
 from AxonDeepSeg.ads_utils import download_data, convert_path, get_existing_models_list, extract_axon_and_myelin_masks_from_image_data, imread, imwrite, get_file_extension, check_available_gpus
@@ -192,23 +191,24 @@ class TestCore(object):
 
     @pytest.mark.unit
     def test_imread_throws_error_for_huge_image(self):
-        filename = 'image_8bit.png'
-        with patch('AxonDeepSeg.ads_utils.get_imshape') as mock_get_imshape:
-            mock_get_imshape.return_value = (10000, 10000, 1)
+        large_image_path = self.tmp_folder / 'image_10000x10000.png'
+        imageio.imwrite(large_image_path, np.zeros((10000, 10000), dtype=np.uint8))
 
+        try:
             with pytest.raises(IOError):
-                imread(self.precision_path / filename)
+                imread(large_image_path)
+        finally:
+            large_image_path.unlink()
 
     @pytest.mark.unit
     def test_imread_successful_for_huge_image_when_allow_large_images_is_true(self):
-        filename = 'image_8bit.png'
-        with patch('AxonDeepSeg.ads_utils.get_imshape') as mock_get_imshape:
-            mock_get_imshape.return_value = (10000, 10000, 1)
+        large_image_path = self.tmp_folder / 'image_10000x10000.png'
+        imageio.imwrite(large_image_path, np.zeros((10000, 10000), dtype=np.uint8))
 
-            try:
-                imread(self.precision_path / filename, allow_large_images=True)
-            except IOError:
-                pytest.fail("imread raised IOError unexpectedly when allow_large_images is True.")
+        try:
+            imread(large_image_path, allow_large_images=True)
+        finally:
+            large_image_path.unlink()
 
     # --------------imwrite tests-------------- #
     @pytest.mark.unit


### PR DESCRIPTION
`get_imshape` called `imageio.v3.improps()` without raising PIL's pixel limit first, so images over ~178 Mpx would throw a `DecompressionBombError` even when `--allow-large-images` was passed.

Fix: propagate `allow_large_images` into `get_imshape` and temporarily raise `Image.MAX_IMAGE_PIXELS` before the imageio call.

Refs #976